### PR TITLE
Adding repository section to package.json to suppress warning from NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "ms",
   "version": "0.6.1",
   "description": "Tiny ms conversion utility",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/guille/ms.js.git"
+  },
   "main": "./index",
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
NPM emits a warning when the repository field is not defined in the `package.json` file:

```
npm WARN package.json ms@0.6.1 No repository field.
```

This pull request adds the repository field. :-)
