### PR TITLE
fix: should return NaN if invalid

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,13 +48,13 @@ module.exports = function(val, options) {
 function parse(str) {
   str = String(str);
   if (str.length > 100) {
-    return;
+    return NaN;
   }
   var match = /^(-?(?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
     str
   );
   if (!match) {
-    return;
+    return NaN;
   }
   var n = parseFloat(match[1]);
   var type = (match[2] || 'ms').toLowerCase();

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function parse(str) {
     case 'ms':
       return n;
     default:
-      return undefined;
+      return NaN;
   }
 }
 

--- a/tests.js
+++ b/tests.js
@@ -10,142 +10,142 @@ if (typeof require !== 'undefined') {
 
 // strings
 
-describe('ms(string)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(string)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms('1m');
     }).to.not.throwError();
   });
 
-  it('should preserve ms', function() {
+  it('should preserve ms', function () {
     expect(ms('100')).to.be(100);
   });
 
-  it('should convert from m to ms', function() {
+  it('should convert from m to ms', function () {
     expect(ms('1m')).to.be(60000);
   });
 
-  it('should convert from h to ms', function() {
+  it('should convert from h to ms', function () {
     expect(ms('1h')).to.be(3600000);
   });
 
-  it('should convert d to ms', function() {
+  it('should convert d to ms', function () {
     expect(ms('2d')).to.be(172800000);
   });
 
-  it('should convert w to ms', function() {
+  it('should convert w to ms', function () {
     expect(ms('3w')).to.be(1814400000);
   });
 
-  it('should convert s to ms', function() {
+  it('should convert s to ms', function () {
     expect(ms('1s')).to.be(1000);
   });
 
-  it('should convert ms to ms', function() {
+  it('should convert ms to ms', function () {
     expect(ms('100ms')).to.be(100);
   });
 
-  it('should work with decimals', function() {
+  it('should work with decimals', function () {
     expect(ms('1.5h')).to.be(5400000);
   });
 
-  it('should work with multiple spaces', function() {
+  it('should work with multiple spaces', function () {
     expect(ms('1   s')).to.be(1000);
   });
 
-  it('should return NaN if invalid', function() {
-    expect(isNaN(ms('☃'))).to.be(true);
-    expect(isNaN(ms('10-.5'))).to.be(true);
+  it('should return NaN if invalid', function () {
+    expect(Number.isNaN(ms('☃'))).to.be(true);
+    expect(Number.isNaN(ms('10-.5'))).to.be(true);
   });
 
-  it('should be case-insensitive', function() {
+  it('should be case-insensitive', function () {
     expect(ms('1.5H')).to.be(5400000);
   });
 
-  it('should work with numbers starting with .', function() {
+  it('should work with numbers starting with .', function () {
     expect(ms('.5ms')).to.be(0.5);
   });
 
-  it('should work with negative integers', function() {
+  it('should work with negative integers', function () {
     expect(ms('-100ms')).to.be(-100);
   });
 
-  it('should work with negative decimals', function() {
+  it('should work with negative decimals', function () {
     expect(ms('-1.5h')).to.be(-5400000);
     expect(ms('-10.5h')).to.be(-37800000);
   });
 
-  it('should work with negative decimals starting with "."', function() {
+  it('should work with negative decimals starting with "."', function () {
     expect(ms('-.5h')).to.be(-1800000);
   });
 });
 
 // long strings
 
-describe('ms(long string)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(long string)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms('53 milliseconds');
     }).to.not.throwError();
   });
 
-  it('should convert milliseconds to ms', function() {
+  it('should convert milliseconds to ms', function () {
     expect(ms('53 milliseconds')).to.be(53);
   });
 
-  it('should convert msecs to ms', function() {
+  it('should convert msecs to ms', function () {
     expect(ms('17 msecs')).to.be(17);
   });
 
-  it('should convert sec to ms', function() {
+  it('should convert sec to ms', function () {
     expect(ms('1 sec')).to.be(1000);
   });
 
-  it('should convert from min to ms', function() {
+  it('should convert from min to ms', function () {
     expect(ms('1 min')).to.be(60000);
   });
 
-  it('should convert from hr to ms', function() {
+  it('should convert from hr to ms', function () {
     expect(ms('1 hr')).to.be(3600000);
   });
 
-  it('should convert days to ms', function() {
+  it('should convert days to ms', function () {
     expect(ms('2 days')).to.be(172800000);
   });
 
-  it('should work with decimals', function() {
+  it('should work with decimals', function () {
     expect(ms('1.5 hours')).to.be(5400000);
   });
 
-  it('should work with negative integers', function() {
+  it('should work with negative integers', function () {
     expect(ms('-100 milliseconds')).to.be(-100);
   });
 
-  it('should work with negative decimals', function() {
+  it('should work with negative decimals', function () {
     expect(ms('-1.5 hours')).to.be(-5400000);
   });
 
-  it('should work with negative decimals starting with "."', function() {
+  it('should work with negative decimals starting with "."', function () {
     expect(ms('-.5 hr')).to.be(-1800000);
   });
 });
 
 // numbers
 
-describe('ms(number, { long: true })', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(number, { long: true })', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms(500, { long: true });
     }).to.not.throwError();
   });
 
-  it('should support milliseconds', function() {
+  it('should support milliseconds', function () {
     expect(ms(500, { long: true })).to.be('500 ms');
 
     expect(ms(-500, { long: true })).to.be('-500 ms');
   });
 
-  it('should support seconds', function() {
+  it('should support seconds', function () {
     expect(ms(1000, { long: true })).to.be('1 second');
     expect(ms(1200, { long: true })).to.be('1 second');
     expect(ms(10000, { long: true })).to.be('10 seconds');
@@ -155,7 +155,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-10000, { long: true })).to.be('-10 seconds');
   });
 
-  it('should support minutes', function() {
+  it('should support minutes', function () {
     expect(ms(60 * 1000, { long: true })).to.be('1 minute');
     expect(ms(60 * 1200, { long: true })).to.be('1 minute');
     expect(ms(60 * 10000, { long: true })).to.be('10 minutes');
@@ -165,7 +165,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 60 * 10000, { long: true })).to.be('-10 minutes');
   });
 
-  it('should support hours', function() {
+  it('should support hours', function () {
     expect(ms(60 * 60 * 1000, { long: true })).to.be('1 hour');
     expect(ms(60 * 60 * 1200, { long: true })).to.be('1 hour');
     expect(ms(60 * 60 * 10000, { long: true })).to.be('10 hours');
@@ -175,7 +175,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 60 * 60 * 10000, { long: true })).to.be('-10 hours');
   });
 
-  it('should support days', function() {
+  it('should support days', function () {
     expect(ms(24 * 60 * 60 * 1000, { long: true })).to.be('1 day');
     expect(ms(24 * 60 * 60 * 1200, { long: true })).to.be('1 day');
     expect(ms(24 * 60 * 60 * 10000, { long: true })).to.be('10 days');
@@ -185,7 +185,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 24 * 60 * 60 * 10000, { long: true })).to.be('-10 days');
   });
 
-  it('should round', function() {
+  it('should round', function () {
     expect(ms(234234234, { long: true })).to.be('3 days');
 
     expect(ms(-234234234, { long: true })).to.be('-3 days');
@@ -194,20 +194,20 @@ describe('ms(number, { long: true })', function() {
 
 // numbers
 
-describe('ms(number)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(number)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms(500);
     }).to.not.throwError();
   });
 
-  it('should support milliseconds', function() {
+  it('should support milliseconds', function () {
     expect(ms(500)).to.be('500ms');
 
     expect(ms(-500)).to.be('-500ms');
   });
 
-  it('should support seconds', function() {
+  it('should support seconds', function () {
     expect(ms(1000)).to.be('1s');
     expect(ms(10000)).to.be('10s');
 
@@ -215,7 +215,7 @@ describe('ms(number)', function() {
     expect(ms(-10000)).to.be('-10s');
   });
 
-  it('should support minutes', function() {
+  it('should support minutes', function () {
     expect(ms(60 * 1000)).to.be('1m');
     expect(ms(60 * 10000)).to.be('10m');
 
@@ -223,7 +223,7 @@ describe('ms(number)', function() {
     expect(ms(-1 * 60 * 10000)).to.be('-10m');
   });
 
-  it('should support hours', function() {
+  it('should support hours', function () {
     expect(ms(60 * 60 * 1000)).to.be('1h');
     expect(ms(60 * 60 * 10000)).to.be('10h');
 
@@ -231,7 +231,7 @@ describe('ms(number)', function() {
     expect(ms(-1 * 60 * 60 * 10000)).to.be('-10h');
   });
 
-  it('should support days', function() {
+  it('should support days', function () {
     expect(ms(24 * 60 * 60 * 1000)).to.be('1d');
     expect(ms(24 * 60 * 60 * 10000)).to.be('10d');
 
@@ -239,7 +239,7 @@ describe('ms(number)', function() {
     expect(ms(-1 * 24 * 60 * 60 * 10000)).to.be('-10d');
   });
 
-  it('should round', function() {
+  it('should round', function () {
     expect(ms(234234234)).to.be('3d');
 
     expect(ms(-234234234)).to.be('-3d');
@@ -248,51 +248,51 @@ describe('ms(number)', function() {
 
 // invalid inputs
 
-describe('ms(invalid inputs)', function() {
-  it('should throw an error, when ms("")', function() {
-    expect(function() {
+describe('ms(invalid inputs)', function () {
+  it('should throw an error, when ms("")', function () {
+    expect(function () {
       ms('');
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(undefined)', function() {
-    expect(function() {
+  it('should throw an error, when ms(undefined)', function () {
+    expect(function () {
       ms(undefined);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(null)', function() {
-    expect(function() {
+  it('should throw an error, when ms(null)', function () {
+    expect(function () {
       ms(null);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms([])', function() {
-    expect(function() {
+  it('should throw an error, when ms([])', function () {
+    expect(function () {
       ms([]);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms({})', function() {
-    expect(function() {
+  it('should throw an error, when ms({})', function () {
+    expect(function () {
       ms({});
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(NaN)', function() {
-    expect(function() {
+  it('should throw an error, when ms(NaN)', function () {
+    expect(function () {
       ms(NaN);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(Infinity)', function() {
-    expect(function() {
+  it('should throw an error, when ms(Infinity)', function () {
+    expect(function () {
       ms(Infinity);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(-Infinity)', function() {
-    expect(function() {
+  it('should throw an error, when ms(-Infinity)', function () {
+    expect(function () {
       ms(-Infinity);
     }).to.throwError();
   });


### PR DESCRIPTION
I don't know if the test case is wrong or the code is wrong，the test cases are as follows:

```js
  it("should return NaN if invalid", function () {
    expect(isNaN(ms("☃"))).to.be(true);
    expect(isNaN(ms("10-.5"))).to.be(true);
  });
```

Because the value returned by the ms is **undefined** and the value of **isNaN(undefined)** is true, the test case passed.

So one of the test cases or code is wrong.