### PR TITLE
Add prettier as a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1535,6 +1535,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "expect.js": "0.3.1",
     "husky": "0.14.3",
     "lint-staged": "5.0.0",
-    "mocha": "4.0.1"
+    "mocha": "4.0.1",
+    "prettier": "2.0.5"
   }
 }


### PR DESCRIPTION
Previously, the project depended on prettier, but it was not listed
as a dev dependency, so the project was expecting it to be
installed globally, which is not a reasonable expectation. This
commit adds the package as a dev dependency so that the git hooks
defined in husky can run properly without a global dependency.