### PR TITLE
Fix fmtShort output

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var y = d * 365.25;
  * @api public
  */
 
-module.exports = function(val, options) {
+module.exports = function (val, options) {
   options = options || {};
   var type = typeof val;
   if (type === 'string' && val.length > 0) {
@@ -113,18 +113,18 @@ function parse(str) {
 function fmtShort(ms) {
   var msAbs = Math.abs(ms);
   if (msAbs >= d) {
-    return Math.round(ms / d) + 'd';
+    return Math.round(ms / d) + ' d';
   }
   if (msAbs >= h) {
-    return Math.round(ms / h) + 'h';
+    return Math.round(ms / h) + ' h';
   }
   if (msAbs >= m) {
-    return Math.round(ms / m) + 'm';
+    return Math.round(ms / m) + ' min';
   }
   if (msAbs >= s) {
-    return Math.round(ms / s) + 's';
+    return Math.round(ms / s) + ' s';
   }
-  return ms + 'ms';
+  return ms + ' ms';
 }
 
 /**

--- a/tests.js
+++ b/tests.js
@@ -10,142 +10,142 @@ if (typeof require !== 'undefined') {
 
 // strings
 
-describe('ms(string)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(string)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms('1m');
     }).to.not.throwError();
   });
 
-  it('should preserve ms', function() {
+  it('should preserve ms', function () {
     expect(ms('100')).to.be(100);
   });
 
-  it('should convert from m to ms', function() {
+  it('should convert from m to ms', function () {
     expect(ms('1m')).to.be(60000);
   });
 
-  it('should convert from h to ms', function() {
+  it('should convert from h to ms', function () {
     expect(ms('1h')).to.be(3600000);
   });
 
-  it('should convert d to ms', function() {
+  it('should convert d to ms', function () {
     expect(ms('2d')).to.be(172800000);
   });
 
-  it('should convert w to ms', function() {
+  it('should convert w to ms', function () {
     expect(ms('3w')).to.be(1814400000);
   });
 
-  it('should convert s to ms', function() {
+  it('should convert s to ms', function () {
     expect(ms('1s')).to.be(1000);
   });
 
-  it('should convert ms to ms', function() {
+  it('should convert ms to ms', function () {
     expect(ms('100ms')).to.be(100);
   });
 
-  it('should work with decimals', function() {
+  it('should work with decimals', function () {
     expect(ms('1.5h')).to.be(5400000);
   });
 
-  it('should work with multiple spaces', function() {
+  it('should work with multiple spaces', function () {
     expect(ms('1   s')).to.be(1000);
   });
 
-  it('should return NaN if invalid', function() {
+  it('should return NaN if invalid', function () {
     expect(isNaN(ms('☃'))).to.be(true);
     expect(isNaN(ms('10-.5'))).to.be(true);
   });
 
-  it('should be case-insensitive', function() {
+  it('should be case-insensitive', function () {
     expect(ms('1.5H')).to.be(5400000);
   });
 
-  it('should work with numbers starting with .', function() {
+  it('should work with numbers starting with .', function () {
     expect(ms('.5ms')).to.be(0.5);
   });
 
-  it('should work with negative integers', function() {
+  it('should work with negative integers', function () {
     expect(ms('-100ms')).to.be(-100);
   });
 
-  it('should work with negative decimals', function() {
+  it('should work with negative decimals', function () {
     expect(ms('-1.5h')).to.be(-5400000);
     expect(ms('-10.5h')).to.be(-37800000);
   });
 
-  it('should work with negative decimals starting with "."', function() {
+  it('should work with negative decimals starting with "."', function () {
     expect(ms('-.5h')).to.be(-1800000);
   });
 });
 
 // long strings
 
-describe('ms(long string)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(long string)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms('53 milliseconds');
     }).to.not.throwError();
   });
 
-  it('should convert milliseconds to ms', function() {
+  it('should convert milliseconds to ms', function () {
     expect(ms('53 milliseconds')).to.be(53);
   });
 
-  it('should convert msecs to ms', function() {
+  it('should convert msecs to ms', function () {
     expect(ms('17 msecs')).to.be(17);
   });
 
-  it('should convert sec to ms', function() {
+  it('should convert sec to ms', function () {
     expect(ms('1 sec')).to.be(1000);
   });
 
-  it('should convert from min to ms', function() {
+  it('should convert from min to ms', function () {
     expect(ms('1 min')).to.be(60000);
   });
 
-  it('should convert from hr to ms', function() {
+  it('should convert from hr to ms', function () {
     expect(ms('1 hr')).to.be(3600000);
   });
 
-  it('should convert days to ms', function() {
+  it('should convert days to ms', function () {
     expect(ms('2 days')).to.be(172800000);
   });
 
-  it('should work with decimals', function() {
+  it('should work with decimals', function () {
     expect(ms('1.5 hours')).to.be(5400000);
   });
 
-  it('should work with negative integers', function() {
+  it('should work with negative integers', function () {
     expect(ms('-100 milliseconds')).to.be(-100);
   });
 
-  it('should work with negative decimals', function() {
+  it('should work with negative decimals', function () {
     expect(ms('-1.5 hours')).to.be(-5400000);
   });
 
-  it('should work with negative decimals starting with "."', function() {
+  it('should work with negative decimals starting with "."', function () {
     expect(ms('-.5 hr')).to.be(-1800000);
   });
 });
 
 // numbers
 
-describe('ms(number, { long: true })', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(number, { long: true })', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms(500, { long: true });
     }).to.not.throwError();
   });
 
-  it('should support milliseconds', function() {
+  it('should support milliseconds', function () {
     expect(ms(500, { long: true })).to.be('500 ms');
 
     expect(ms(-500, { long: true })).to.be('-500 ms');
   });
 
-  it('should support seconds', function() {
+  it('should support seconds', function () {
     expect(ms(1000, { long: true })).to.be('1 second');
     expect(ms(1200, { long: true })).to.be('1 second');
     expect(ms(10000, { long: true })).to.be('10 seconds');
@@ -155,7 +155,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-10000, { long: true })).to.be('-10 seconds');
   });
 
-  it('should support minutes', function() {
+  it('should support minutes', function () {
     expect(ms(60 * 1000, { long: true })).to.be('1 minute');
     expect(ms(60 * 1200, { long: true })).to.be('1 minute');
     expect(ms(60 * 10000, { long: true })).to.be('10 minutes');
@@ -165,7 +165,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 60 * 10000, { long: true })).to.be('-10 minutes');
   });
 
-  it('should support hours', function() {
+  it('should support hours', function () {
     expect(ms(60 * 60 * 1000, { long: true })).to.be('1 hour');
     expect(ms(60 * 60 * 1200, { long: true })).to.be('1 hour');
     expect(ms(60 * 60 * 10000, { long: true })).to.be('10 hours');
@@ -175,7 +175,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 60 * 60 * 10000, { long: true })).to.be('-10 hours');
   });
 
-  it('should support days', function() {
+  it('should support days', function () {
     expect(ms(24 * 60 * 60 * 1000, { long: true })).to.be('1 day');
     expect(ms(24 * 60 * 60 * 1200, { long: true })).to.be('1 day');
     expect(ms(24 * 60 * 60 * 10000, { long: true })).to.be('10 days');
@@ -185,7 +185,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 24 * 60 * 60 * 10000, { long: true })).to.be('-10 days');
   });
 
-  it('should round', function() {
+  it('should round', function () {
     expect(ms(234234234, { long: true })).to.be('3 days');
 
     expect(ms(-234234234, { long: true })).to.be('-3 days');
@@ -194,105 +194,105 @@ describe('ms(number, { long: true })', function() {
 
 // numbers
 
-describe('ms(number)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(number)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms(500);
     }).to.not.throwError();
   });
 
-  it('should support milliseconds', function() {
-    expect(ms(500)).to.be('500ms');
+  it('should support milliseconds', function () {
+    expect(ms(500)).to.be('500 ms');
 
-    expect(ms(-500)).to.be('-500ms');
+    expect(ms(-500)).to.be('-500 ms');
   });
 
-  it('should support seconds', function() {
-    expect(ms(1000)).to.be('1s');
-    expect(ms(10000)).to.be('10s');
+  it('should support seconds', function () {
+    expect(ms(1000)).to.be('1 s');
+    expect(ms(10000)).to.be('10 s');
 
-    expect(ms(-1000)).to.be('-1s');
-    expect(ms(-10000)).to.be('-10s');
+    expect(ms(-1000)).to.be('-1 s');
+    expect(ms(-10000)).to.be('-10 s');
   });
 
-  it('should support minutes', function() {
-    expect(ms(60 * 1000)).to.be('1m');
-    expect(ms(60 * 10000)).to.be('10m');
+  it('should support minutes', function () {
+    expect(ms(60 * 1000)).to.be('1 min');
+    expect(ms(60 * 10000)).to.be('10 min');
 
-    expect(ms(-1 * 60 * 1000)).to.be('-1m');
-    expect(ms(-1 * 60 * 10000)).to.be('-10m');
+    expect(ms(-1 * 60 * 1000)).to.be('-1 min');
+    expect(ms(-1 * 60 * 10000)).to.be('-10 min');
   });
 
-  it('should support hours', function() {
-    expect(ms(60 * 60 * 1000)).to.be('1h');
-    expect(ms(60 * 60 * 10000)).to.be('10h');
+  it('should support hours', function () {
+    expect(ms(60 * 60 * 1000)).to.be('1 h');
+    expect(ms(60 * 60 * 10000)).to.be('10 h');
 
-    expect(ms(-1 * 60 * 60 * 1000)).to.be('-1h');
-    expect(ms(-1 * 60 * 60 * 10000)).to.be('-10h');
+    expect(ms(-1 * 60 * 60 * 1000)).to.be('-1 h');
+    expect(ms(-1 * 60 * 60 * 10000)).to.be('-10 h');
   });
 
-  it('should support days', function() {
-    expect(ms(24 * 60 * 60 * 1000)).to.be('1d');
-    expect(ms(24 * 60 * 60 * 10000)).to.be('10d');
+  it('should support days', function () {
+    expect(ms(24 * 60 * 60 * 1000)).to.be('1 d');
+    expect(ms(24 * 60 * 60 * 10000)).to.be('10 d');
 
-    expect(ms(-1 * 24 * 60 * 60 * 1000)).to.be('-1d');
-    expect(ms(-1 * 24 * 60 * 60 * 10000)).to.be('-10d');
+    expect(ms(-1 * 24 * 60 * 60 * 1000)).to.be('-1 d');
+    expect(ms(-1 * 24 * 60 * 60 * 10000)).to.be('-10 d');
   });
 
-  it('should round', function() {
-    expect(ms(234234234)).to.be('3d');
+  it('should round', function () {
+    expect(ms(234234234)).to.be('3 d');
 
-    expect(ms(-234234234)).to.be('-3d');
+    expect(ms(-234234234)).to.be('-3 d');
   });
 });
 
 // invalid inputs
 
-describe('ms(invalid inputs)', function() {
-  it('should throw an error, when ms("")', function() {
-    expect(function() {
+describe('ms(invalid inputs)', function () {
+  it('should throw an error, when ms("")', function () {
+    expect(function () {
       ms('');
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(undefined)', function() {
-    expect(function() {
+  it('should throw an error, when ms(undefined)', function () {
+    expect(function () {
       ms(undefined);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(null)', function() {
-    expect(function() {
+  it('should throw an error, when ms(null)', function () {
+    expect(function () {
       ms(null);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms([])', function() {
-    expect(function() {
+  it('should throw an error, when ms([])', function () {
+    expect(function () {
       ms([]);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms({})', function() {
-    expect(function() {
+  it('should throw an error, when ms({})', function () {
+    expect(function () {
       ms({});
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(NaN)', function() {
-    expect(function() {
+  it('should throw an error, when ms(NaN)', function () {
+    expect(function () {
       ms(NaN);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(Infinity)', function() {
-    expect(function() {
+  it('should throw an error, when ms(Infinity)', function () {
+    expect(function () {
       ms(Infinity);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(-Infinity)', function() {
-    expect(function() {
+  it('should throw an error, when ms(-Infinity)', function () {
+    expect(function () {
       ms(-Infinity);
     }).to.throwError();
   });


### PR DESCRIPTION
Previously, the output from the fmtShort function did not have a
space between the quantity and the unit symbol, which is incorrect.
It also had the symbol for the minute as "m", which is also
incorrect. This commit fixes both of these issues.

Fixes #134 