### PR TITLE
docs: added bree as a related package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ ms(ms('10 hours'), { long: true })    // "10 hours"
 
 ## Related Packages
 
+- [bree](https://jobscheduler.net) - Bree is a job scheduler for Node.js with built-in support for workers, cron expression syntax, human-friendly times, Dates, and more.
 - [ms.macro](https://github.com/knpwrs/ms.macro) - Run `ms` as a macro at build-time.
 
 ## Caught a Bug?


### PR DESCRIPTION
I recently created the npm package `bree` which is now becoming very popular.  Bree is a job scheduler for Node.js using Worker threads with support for cron, dates, ms, later, and human-friendly strings.  I thought it would be great to mention it here since it uses `ms` and has support for it directly.  It is also a nice way to highlight how awesome `ms` is.

Site/Docs: https://jobscheduler.net
GitHub Repo: https://github.com/breejs/bree