### PR TITLE
Rename zeit to vercel

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Vercel, Inc.
+Copyright (c) 2020 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Zeit, Inc.
+Copyright (c) 2016 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ms",
   "version": "2.1.2",
   "description": "Tiny millisecond conversion utility",
-  "repository": "zeit/ms",
+  "repository": "vercel/ms",
   "main": "./index",
   "files": [
     "index.js"

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 # ms
 
-[![Build Status](https://travis-ci.org/zeit/ms.svg?branch=master)](https://travis-ci.org/zeit/ms)
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/zeit)
+[![Build Status](https://travis-ci.org/vercel/ms.svg?branch=master)](https://travis-ci.org/vercel/ms)
 
 Use this package to easily convert various time formats to milliseconds.
 


### PR DESCRIPTION
Closes #143 

See https://vercel.com/blog/zeit-is-now-vercel