### PR TITLE
added the option to round the output to the nearest preferred unit

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,12 @@ module.exports = function (val, options) {
   if (type === 'string' && val.length > 0) {
     return parse(val);
   } else if (type === 'number' && isFinite(val)) {
+    if (options.roundTo === 'd') return roundTo(val, d, options.long);
+    if (options.roundTo === 'h') return roundTo(val, h, options.long);
+    if (options.roundTo === 'm') return roundTo(val, m, options.long);
+    if (options.roundTo === 's') return roundTo(val, s, options.long);
+    if (options.roundTo === 'ms') return roundTo(val, 1, options.long);
+
     return options.long ? fmtLong(val) : fmtShort(val);
   }
   throw new Error(
@@ -159,4 +165,74 @@ function fmtLong(ms) {
 function plural(ms, msAbs, n, name) {
   var isPlural = msAbs >= n * 1.5;
   return Math.round(ms / n) + ' ' + name + (isPlural ? 's' : '');
+}
+
+/**
+ * Optional rounding to the nearest unit of days, hours, minutes, seconds or milliseconds
+ *
+ * @param {Number} ms
+ * @param {Number} format this takes the values d | h | m | s | 1
+ * @param {Boolean} long
+ * @return {String}
+ * @api private
+ */
+function roundTo(ms, format, long) {
+  const msAbs = Math.abs(ms);
+  let remainder = ms;
+  let result = '';
+
+  if (msAbs >= d && format <= d) {
+    const totalDays = remainder / d;
+    const totalDaysInteger =
+      format === d ? Math.round(totalDays) : Math.floor(totalDays);
+    const totalDaysIntegerInMS = totalDaysInteger * d;
+    remainder -= totalDaysIntegerInMS;
+    result += long
+      ? fmtLong(totalDaysIntegerInMS)
+      : fmtShort(totalDaysIntegerInMS);
+    result += ' ';
+  }
+
+  if (msAbs >= h && format <= h) {
+    const totalHours = remainder / h;
+    const totalHoursInteger =
+      format === h ? Math.round(totalHours) : Math.floor(totalHours);
+    const totalHoursIntegerInMS = totalHoursInteger * h;
+    remainder -= totalHoursIntegerInMS;
+    result += long
+      ? fmtLong(totalHoursIntegerInMS)
+      : fmtShort(totalHoursIntegerInMS);
+    result += ' ';
+  }
+
+  if (msAbs >= m && format <= m) {
+    const totalMinutes = remainder / m;
+    const totalMinutesInteger =
+      format === m ? Math.round(totalMinutes) : Math.floor(totalMinutes);
+    const totalMinutesIntegerInMS = totalMinutesInteger * m;
+    remainder -= totalMinutesIntegerInMS;
+    result += long
+      ? fmtLong(totalMinutesIntegerInMS)
+      : fmtShort(totalMinutesIntegerInMS);
+    result += ' ';
+  }
+
+  if (msAbs >= s && format <= s) {
+    const totalSeconds = remainder / s;
+    const totalSecondsInteger =
+      format === s ? Math.round(totalSeconds) : Math.floor(totalSeconds);
+    const totalSecondsIntegerInMS = totalSecondsInteger * s;
+    remainder -= totalSecondsIntegerInMS;
+    result += long
+      ? fmtLong(totalSecondsIntegerInMS)
+      : fmtShort(totalSecondsIntegerInMS);
+    result += ' ';
+  }
+
+  if (format < s) {
+    result += long ? fmtLong(remainder) : fmtShort(remainder);
+    result += ' ';
+  }
+
+  return result.trim();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "babel-code-frame": {
@@ -131,7 +131,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -168,9 +168,9 @@
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -179,7 +179,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "supports-color": {
@@ -188,7 +188,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -233,7 +233,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -242,7 +242,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "slice-ansi": {
@@ -257,9 +257,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -268,7 +268,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -297,7 +297,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -342,10 +342,10 @@
       "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
       "dev": true,
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.10.0",
-        "parse-json": "3.0.0",
-        "require-from-string": "2.0.1"
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^3.0.0",
+        "require-from-string": "^2.0.1"
       }
     },
     "cross-spawn": {
@@ -354,9 +354,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "date-fns": {
@@ -413,7 +413,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -535,13 +535,13 @@
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exit-hook": {
@@ -652,12 +652,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -684,7 +684,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -705,9 +705,9 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "1.0.10",
-        "normalize-path": "1.0.0",
-        "strip-indent": "2.0.0"
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "iconv-lite": {
@@ -737,7 +737,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -746,8 +746,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -790,7 +790,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.2"
+        "ci-info": "^1.0.0"
       }
     },
     "is-directory": {
@@ -811,7 +811,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -826,7 +826,7 @@
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-obj": {
@@ -841,7 +841,7 @@
       "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
       "dev": true,
       "requires": {
-        "symbol-observable": "0.2.4"
+        "symbol-observable": "^0.2.2"
       }
     },
     "is-promise": {
@@ -892,10 +892,10 @@
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "jest-get-type": "21.2.0",
-        "leven": "2.1.0",
-        "pretty-format": "21.2.1"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^21.2.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^21.2.1"
       }
     },
     "js-tokens": {
@@ -910,8 +910,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json-schema-traverse": {
@@ -948,25 +948,25 @@
       "integrity": "sha512-nKwjLlYOd6Eqog3cg3aDulrRfLkR3GPasqTI7+3ZKucLATqay86wOaEM0gtYVmTS0/ihHSARnOWduAqNJZAbeQ==",
       "dev": true,
       "requires": {
-        "app-root-path": "2.0.1",
-        "chalk": "2.3.0",
-        "commander": "2.12.2",
-        "cosmiconfig": "3.1.0",
-        "dedent": "0.7.0",
-        "execa": "0.8.0",
-        "find-parent-dir": "0.3.0",
-        "is-glob": "4.0.0",
-        "jest-validate": "21.2.1",
-        "listr": "0.13.0",
-        "lodash": "4.17.4",
-        "log-symbols": "2.1.0",
-        "minimatch": "3.0.4",
-        "npm-which": "3.0.1",
-        "p-map": "1.2.0",
-        "path-is-inside": "1.0.2",
-        "pify": "3.0.0",
+        "app-root-path": "^2.0.0",
+        "chalk": "^2.1.0",
+        "commander": "^2.11.0",
+        "cosmiconfig": "^3.1.0",
+        "dedent": "^0.7.0",
+        "execa": "^0.8.0",
+        "find-parent-dir": "^0.3.0",
+        "is-glob": "^4.0.0",
+        "jest-validate": "^21.1.0",
+        "listr": "^0.13.0",
+        "lodash": "^4.17.4",
+        "log-symbols": "^2.0.0",
+        "minimatch": "^3.0.0",
+        "npm-which": "^3.0.1",
+        "p-map": "^1.1.1",
+        "path-is-inside": "^1.0.2",
+        "pify": "^3.0.0",
         "staged-git-files": "0.0.4",
-        "stringify-object": "3.2.1"
+        "stringify-object": "^3.2.0"
       },
       "dependencies": {
         "pify": {
@@ -983,23 +983,23 @@
       "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "figures": "1.7.0",
-        "indent-string": "2.1.0",
-        "is-observable": "0.2.0",
-        "is-promise": "2.1.0",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.4.0",
-        "listr-verbose-renderer": "0.4.1",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "ora": "0.2.3",
-        "p-map": "1.2.0",
-        "rxjs": "5.5.2",
-        "stream-to-observable": "0.2.0",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "figures": "^1.7.0",
+        "indent-string": "^2.1.0",
+        "is-observable": "^0.2.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.4.0",
+        "listr-verbose-renderer": "^0.4.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "ora": "^0.2.3",
+        "p-map": "^1.1.1",
+        "rxjs": "^5.4.2",
+        "stream-to-observable": "^0.2.0",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -1008,11 +1008,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "figures": {
@@ -1021,8 +1021,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "log-symbols": {
@@ -1031,7 +1031,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "strip-ansi": {
@@ -1040,7 +1040,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -1057,14 +1057,14 @@
       "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -1073,11 +1073,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "figures": {
@@ -1086,8 +1086,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "indent-string": {
@@ -1102,7 +1102,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "strip-ansi": {
@@ -1111,7 +1111,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -1122,10 +1122,10 @@
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "date-fns": "1.29.0",
-        "figures": "1.7.0"
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
       },
       "dependencies": {
         "chalk": {
@@ -1134,11 +1134,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-cursor": {
@@ -1147,7 +1147,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "figures": {
@@ -1156,8 +1156,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "onetime": {
@@ -1172,8 +1172,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "strip-ansi": {
@@ -1182,7 +1182,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -1199,7 +1199,7 @@
       "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0"
+        "chalk": "^2.0.1"
       }
     },
     "log-update": {
@@ -1208,8 +1208,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -1224,7 +1224,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "onetime": {
@@ -1239,8 +1239,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         }
       }
@@ -1251,8 +1251,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "mimic-fn": {
@@ -1267,7 +1267,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1315,7 +1315,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -1350,7 +1350,7 @@
       "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
       "dev": true,
       "requires": {
-        "which": "1.3.0"
+        "which": "^1.2.10"
       }
     },
     "npm-run-path": {
@@ -1359,7 +1359,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npm-which": {
@@ -1368,9 +1368,9 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
-        "npm-path": "2.0.3",
-        "which": "1.3.0"
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
       }
     },
     "number-is-nan": {
@@ -1391,7 +1391,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1423,10 +1423,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -1435,11 +1435,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-cursor": {
@@ -1448,7 +1448,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "onetime": {
@@ -1463,8 +1463,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "strip-ansi": {
@@ -1473,7 +1473,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -1502,7 +1502,7 @@
       "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.3.1"
       }
     },
     "path-is-absolute": {
@@ -1547,8 +1547,8 @@
       "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.0"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1563,7 +1563,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         }
       }
@@ -1607,7 +1607,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "require-from-string": {
@@ -1697,7 +1697,7 @@
       "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.1.0"
+        "symbol-observable": "^1.0.1"
       },
       "dependencies": {
         "symbol-observable": {
@@ -1732,7 +1732,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -1774,7 +1774,7 @@
       "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
       "dev": true,
       "requires": {
-        "any-observable": "0.2.0"
+        "any-observable": "^0.2.0"
       }
     },
     "string-width": {
@@ -1802,9 +1802,9 @@
       "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "2.0.1",
-        "is-obj": "1.0.1",
-        "is-regexp": "1.0.0"
+        "get-own-enumerable-property-symbols": "^2.0.1",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -1916,7 +1916,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {

--- a/tests.js
+++ b/tests.js
@@ -10,142 +10,142 @@ if (typeof require !== 'undefined') {
 
 // strings
 
-describe('ms(string)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(string)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms('1m');
     }).to.not.throwError();
   });
 
-  it('should preserve ms', function() {
+  it('should preserve ms', function () {
     expect(ms('100')).to.be(100);
   });
 
-  it('should convert from m to ms', function() {
+  it('should convert from m to ms', function () {
     expect(ms('1m')).to.be(60000);
   });
 
-  it('should convert from h to ms', function() {
+  it('should convert from h to ms', function () {
     expect(ms('1h')).to.be(3600000);
   });
 
-  it('should convert d to ms', function() {
+  it('should convert d to ms', function () {
     expect(ms('2d')).to.be(172800000);
   });
 
-  it('should convert w to ms', function() {
+  it('should convert w to ms', function () {
     expect(ms('3w')).to.be(1814400000);
   });
 
-  it('should convert s to ms', function() {
+  it('should convert s to ms', function () {
     expect(ms('1s')).to.be(1000);
   });
 
-  it('should convert ms to ms', function() {
+  it('should convert ms to ms', function () {
     expect(ms('100ms')).to.be(100);
   });
 
-  it('should work with decimals', function() {
+  it('should work with decimals', function () {
     expect(ms('1.5h')).to.be(5400000);
   });
 
-  it('should work with multiple spaces', function() {
+  it('should work with multiple spaces', function () {
     expect(ms('1   s')).to.be(1000);
   });
 
-  it('should return NaN if invalid', function() {
+  it('should return NaN if invalid', function () {
     expect(isNaN(ms('☃'))).to.be(true);
     expect(isNaN(ms('10-.5'))).to.be(true);
   });
 
-  it('should be case-insensitive', function() {
+  it('should be case-insensitive', function () {
     expect(ms('1.5H')).to.be(5400000);
   });
 
-  it('should work with numbers starting with .', function() {
+  it('should work with numbers starting with .', function () {
     expect(ms('.5ms')).to.be(0.5);
   });
 
-  it('should work with negative integers', function() {
+  it('should work with negative integers', function () {
     expect(ms('-100ms')).to.be(-100);
   });
 
-  it('should work with negative decimals', function() {
+  it('should work with negative decimals', function () {
     expect(ms('-1.5h')).to.be(-5400000);
     expect(ms('-10.5h')).to.be(-37800000);
   });
 
-  it('should work with negative decimals starting with "."', function() {
+  it('should work with negative decimals starting with "."', function () {
     expect(ms('-.5h')).to.be(-1800000);
   });
 });
 
 // long strings
 
-describe('ms(long string)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(long string)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms('53 milliseconds');
     }).to.not.throwError();
   });
 
-  it('should convert milliseconds to ms', function() {
+  it('should convert milliseconds to ms', function () {
     expect(ms('53 milliseconds')).to.be(53);
   });
 
-  it('should convert msecs to ms', function() {
+  it('should convert msecs to ms', function () {
     expect(ms('17 msecs')).to.be(17);
   });
 
-  it('should convert sec to ms', function() {
+  it('should convert sec to ms', function () {
     expect(ms('1 sec')).to.be(1000);
   });
 
-  it('should convert from min to ms', function() {
+  it('should convert from min to ms', function () {
     expect(ms('1 min')).to.be(60000);
   });
 
-  it('should convert from hr to ms', function() {
+  it('should convert from hr to ms', function () {
     expect(ms('1 hr')).to.be(3600000);
   });
 
-  it('should convert days to ms', function() {
+  it('should convert days to ms', function () {
     expect(ms('2 days')).to.be(172800000);
   });
 
-  it('should work with decimals', function() {
+  it('should work with decimals', function () {
     expect(ms('1.5 hours')).to.be(5400000);
   });
 
-  it('should work with negative integers', function() {
+  it('should work with negative integers', function () {
     expect(ms('-100 milliseconds')).to.be(-100);
   });
 
-  it('should work with negative decimals', function() {
+  it('should work with negative decimals', function () {
     expect(ms('-1.5 hours')).to.be(-5400000);
   });
 
-  it('should work with negative decimals starting with "."', function() {
+  it('should work with negative decimals starting with "."', function () {
     expect(ms('-.5 hr')).to.be(-1800000);
   });
 });
 
 // numbers
 
-describe('ms(number, { long: true })', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(number, { long: true })', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms(500, { long: true });
     }).to.not.throwError();
   });
 
-  it('should support milliseconds', function() {
+  it('should support milliseconds', function () {
     expect(ms(500, { long: true })).to.be('500 ms');
 
     expect(ms(-500, { long: true })).to.be('-500 ms');
   });
 
-  it('should support seconds', function() {
+  it('should support seconds', function () {
     expect(ms(1000, { long: true })).to.be('1 second');
     expect(ms(1200, { long: true })).to.be('1 second');
     expect(ms(10000, { long: true })).to.be('10 seconds');
@@ -155,7 +155,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-10000, { long: true })).to.be('-10 seconds');
   });
 
-  it('should support minutes', function() {
+  it('should support minutes', function () {
     expect(ms(60 * 1000, { long: true })).to.be('1 minute');
     expect(ms(60 * 1200, { long: true })).to.be('1 minute');
     expect(ms(60 * 10000, { long: true })).to.be('10 minutes');
@@ -165,7 +165,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 60 * 10000, { long: true })).to.be('-10 minutes');
   });
 
-  it('should support hours', function() {
+  it('should support hours', function () {
     expect(ms(60 * 60 * 1000, { long: true })).to.be('1 hour');
     expect(ms(60 * 60 * 1200, { long: true })).to.be('1 hour');
     expect(ms(60 * 60 * 10000, { long: true })).to.be('10 hours');
@@ -175,7 +175,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 60 * 60 * 10000, { long: true })).to.be('-10 hours');
   });
 
-  it('should support days', function() {
+  it('should support days', function () {
     expect(ms(24 * 60 * 60 * 1000, { long: true })).to.be('1 day');
     expect(ms(24 * 60 * 60 * 1200, { long: true })).to.be('1 day');
     expect(ms(24 * 60 * 60 * 10000, { long: true })).to.be('10 days');
@@ -185,7 +185,7 @@ describe('ms(number, { long: true })', function() {
     expect(ms(-1 * 24 * 60 * 60 * 10000, { long: true })).to.be('-10 days');
   });
 
-  it('should round', function() {
+  it('should round', function () {
     expect(ms(234234234, { long: true })).to.be('3 days');
 
     expect(ms(-234234234, { long: true })).to.be('-3 days');
@@ -194,20 +194,102 @@ describe('ms(number, { long: true })', function() {
 
 // numbers
 
-describe('ms(number)', function() {
-  it('should not throw an error', function() {
-    expect(function() {
+describe('ms(number, { long: true, roundTo: "d" | "h" | "m" | "s" })', function () {
+  it('should not throw an error', function () {
+    expect(function () {
+      ms(500, { long: true, roundTo: 'h' });
+    }).to.not.throwError();
+  });
+
+  it('should support milliseconds', function () {
+    expect(ms(500, { long: true, roundTo: 'ms' })).to.be('500 ms');
+
+    expect(ms(-500, { long: true, roundTo: 'ms' })).to.be('-500 ms');
+  });
+
+  it('should support seconds', function () {
+    expect(ms(1000, { long: true, roundTo: 's' })).to.be('1 second');
+    expect(ms(10000, { long: true, roundTo: 's' })).to.be('10 seconds');
+    expect(ms(1200, { long: true, roundTo: 's' })).to.be('1 second');
+    expect(ms(1200, { long: true, roundTo: 'ms' })).to.be('1 second 200 ms');
+
+    // expect(ms(-1000, { long: true, roundTo: 's' })).to.be('-1 second');
+    // expect(ms(-10000, { long: true, roundTo: 's' })).to.be('-10 seconds');
+    // expect(ms(-1200, { long: true, roundTo: 's' })).to.be('');
+    // expect(ms(-1200, { long: true, roundTo: 'ms' })).to.be('');
+  });
+
+  it('should support minutes', function () {
+    expect(ms(60 * 1000, { long: true, roundTo: 'm' })).to.be('1 minute');
+    expect(ms(60 * 10000, { long: true, roundTo: 'm' })).to.be('10 minutes');
+    expect(ms(60 * 1000 + 2000, { long: true, roundTo: 'm' })).to.be(
+      '1 minute'
+    );
+    expect(ms(60 * 1000 + 2000, { long: true, roundTo: 's' })).to.be(
+      '1 minute 2 seconds'
+    );
+    expect(ms(60 * 1000 + 2000 + 200, { long: true, roundTo: 'ms' })).to.be(
+      '1 minute 2 seconds 200 ms'
+    );
+
+    // expect(ms(-1 * 60 * 1000, { long: true, roundTo: 'm' })).to.be('-1 minute');
+    // expect(ms(-1 * 60 * 10000, { long: true, roundTo: 'm' })).to.be('-10 minutes');
+    // expect(ms(-1 * 60 * 1000 - 2000, { long: true, roundTo: 'm' })).to.be('');
+    // expect(ms(-1 * 60 * 1000 - 2000, { long: true, roundTo: 's' })).to.be('');
+    // expect(ms(-1 * 60 * 1000 - 2000 - 200, { long: true, roundTo: 'ms' })).to.be('');
+  });
+
+  it('should support hours', function () {
+    expect(ms(60 * 60 * 1000, { long: true, roundTo: 'h' })).to.be('1 hour');
+    expect(ms(60 * 60 * 10000, { long: true, roundTo: 'h' })).to.be('10 hours');
+    expect(
+      ms(60 * 60 * 1000 + 60 * 2000 + 2000 + 200, { long: true, roundTo: 'ms' })
+    ).to.be('1 hour 2 minutes 2 seconds 200 ms');
+
+    // expect(ms(-1 * 60 * 60 * 1000, { long: true, roundTo: 'h' })).to.be('-1 hour');
+    // expect(ms(-1 * 60 * 60 * 10000, { long: true, roundTo: 'h' })).to.be('-10 hours');
+    // expect(ms(-1 * 60 * 60 * 1000 - 60 * 2000 - 2000 - 200, { long: true, roundTo: 'ms' })).to.be('');
+  });
+
+  it('should support days', function () {
+    expect(ms(24 * 60 * 60 * 1000, { long: true, roundTo: 'd' })).to.be(
+      '1 day'
+    );
+    expect(ms(24 * 60 * 60 * 10000, { long: true, roundTo: 'd' })).to.be(
+      '10 days'
+    );
+    expect(ms(24 * 60 * 60 * 1200, { long: true, roundTo: 'd' })).to.be(
+      '1 day'
+    );
+    expect(
+      ms(24 * 60 * 60 * 1000 + 60 * 60 * 2000 + 60 * 2000 + 2000 + 200, {
+        long: true,
+        roundTo: 'ms',
+      })
+    ).to.be('1 day 2 hours 2 minutes 2 seconds 200 ms');
+
+    // expect(ms(-1 * 24 * 60 * 60 * 1000, { long: true, roundTo: 'd' })).to.be('-1 day');
+    // expect(ms(-1 * 24 * 60 * 60 * 10000, { long: true, roundTo: 'd' })).to.be('-10 days');
+    // expect(ms(-1 * 24 * 60 * 60 * 1000 - 60 * 60 * 2000 - 60 * 2000 - 2000 - 200, { long: true, roundTo: 'ms' })).to.be('');
+  });
+});
+
+// numbers
+
+describe('ms(number)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
       ms(500);
     }).to.not.throwError();
   });
 
-  it('should support milliseconds', function() {
+  it('should support milliseconds', function () {
     expect(ms(500)).to.be('500ms');
 
     expect(ms(-500)).to.be('-500ms');
   });
 
-  it('should support seconds', function() {
+  it('should support seconds', function () {
     expect(ms(1000)).to.be('1s');
     expect(ms(10000)).to.be('10s');
 
@@ -215,7 +297,7 @@ describe('ms(number)', function() {
     expect(ms(-10000)).to.be('-10s');
   });
 
-  it('should support minutes', function() {
+  it('should support minutes', function () {
     expect(ms(60 * 1000)).to.be('1m');
     expect(ms(60 * 10000)).to.be('10m');
 
@@ -223,7 +305,7 @@ describe('ms(number)', function() {
     expect(ms(-1 * 60 * 10000)).to.be('-10m');
   });
 
-  it('should support hours', function() {
+  it('should support hours', function () {
     expect(ms(60 * 60 * 1000)).to.be('1h');
     expect(ms(60 * 60 * 10000)).to.be('10h');
 
@@ -231,7 +313,7 @@ describe('ms(number)', function() {
     expect(ms(-1 * 60 * 60 * 10000)).to.be('-10h');
   });
 
-  it('should support days', function() {
+  it('should support days', function () {
     expect(ms(24 * 60 * 60 * 1000)).to.be('1d');
     expect(ms(24 * 60 * 60 * 10000)).to.be('10d');
 
@@ -239,7 +321,7 @@ describe('ms(number)', function() {
     expect(ms(-1 * 24 * 60 * 60 * 10000)).to.be('-10d');
   });
 
-  it('should round', function() {
+  it('should round', function () {
     expect(ms(234234234)).to.be('3d');
 
     expect(ms(-234234234)).to.be('-3d');
@@ -248,51 +330,51 @@ describe('ms(number)', function() {
 
 // invalid inputs
 
-describe('ms(invalid inputs)', function() {
-  it('should throw an error, when ms("")', function() {
-    expect(function() {
+describe('ms(invalid inputs)', function () {
+  it('should throw an error, when ms("")', function () {
+    expect(function () {
       ms('');
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(undefined)', function() {
-    expect(function() {
+  it('should throw an error, when ms(undefined)', function () {
+    expect(function () {
       ms(undefined);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(null)', function() {
-    expect(function() {
+  it('should throw an error, when ms(null)', function () {
+    expect(function () {
       ms(null);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms([])', function() {
-    expect(function() {
+  it('should throw an error, when ms([])', function () {
+    expect(function () {
       ms([]);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms({})', function() {
-    expect(function() {
+  it('should throw an error, when ms({})', function () {
+    expect(function () {
       ms({});
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(NaN)', function() {
-    expect(function() {
+  it('should throw an error, when ms(NaN)', function () {
+    expect(function () {
       ms(NaN);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(Infinity)', function() {
-    expect(function() {
+  it('should throw an error, when ms(Infinity)', function () {
+    expect(function () {
       ms(Infinity);
     }).to.throwError();
   });
 
-  it('should throw an error, when ms(-Infinity)', function() {
-    expect(function() {
+  it('should throw an error, when ms(-Infinity)', function () {
+    expect(function () {
       ms(-Infinity);
     }).to.throwError();
   });


### PR DESCRIPTION
solved [this issue](https://github.com/vercel/ms/issues/142) by adding the option to round to the nearest preferred unit, so now `ms(5400000, { roundTo: 'm'}) ` should return 1h 30m rather than 2h