### PR TITLE
Support optional rounding

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -182,6 +182,34 @@ describe('ms(number, { long: true })', function () {
 
     expect(ms(-234234234, { long: true })).toBe('-3 days');
   });
+
+  it('should not round', function () {
+    expect(ms(4.56789 * 1000, { long: true, round: false })).toBe(
+      '4.56789 seconds',
+    );
+
+    expect(ms(-4.56789 * 1000, { long: true, round: false })).toBe(
+      '-4.56789 seconds',
+    );
+  });
+
+  it(`should round to precision 1 (0.1)`, function () {
+    expect(ms(4.567 * 1000, { long: true, round: 1 })).toBe('4.6 seconds');
+
+    expect(ms(-4.567 * 1000, { long: true, round: 1 })).toBe('-4.6 seconds');
+  });
+
+  it(`should round to precision 2 (0.01)`, function () {
+    expect(ms(4.567 * 1000, { long: true, round: 2 })).toBe('4.57 seconds');
+
+    expect(ms(-4.567 * 1000, { long: true, round: 2 })).toBe('-4.57 seconds');
+  });
+
+  it(`should round to precision 3 (0.001)`, function () {
+    expect(ms(4.567 * 1000, { long: true, round: 3 })).toBe('4.567 seconds');
+
+    expect(ms(-4.567 * 1000, { long: true, round: 3 })).toBe('-4.567 seconds');
+  });
 });
 
 // numbers
@@ -235,6 +263,30 @@ describe('ms(number)', function () {
     expect(ms(234234234)).toBe('3d');
 
     expect(ms(-234234234)).toBe('-3d');
+  });
+
+  it('should not round', function () {
+    expect(ms(4.56789 * 1000, { round: false })).toBe('4.56789s');
+
+    expect(ms(-4.56789 * 1000, { round: false })).toBe('-4.56789s');
+  });
+
+  it(`should round to precision 1 (0.1)`, function () {
+    expect(ms(4.567 * 1000, { round: 1 })).toBe('4.6s');
+
+    expect(ms(-4.567 * 1000, { round: 1 })).toBe('-4.6s');
+  });
+
+  it(`should round to precision 2 (0.01)`, function () {
+    expect(ms(4.567 * 1000, { round: 2 })).toBe('4.57s');
+
+    expect(ms(-4.567 * 1000, { round: 2 })).toBe('-4.57s');
+  });
+
+  it(`should round to precision 3 (0.001)`, function () {
+    expect(ms(4.567 * 1000, { round: 3 })).toBe('4.567s');
+
+    expect(ms(-4.567 * 1000, { round: 3 })).toBe('-4.567s');
   });
 });
 


### PR DESCRIPTION
This PR enables rounding through the `round`﻿option.

`round` defaults to true and current solutions will continue to behave the same.

When `round` is set to false, all rounding is disabled.

When `round` is set to a number, it is used as precision for `toFixed`.
