### PR TITLE
Handle case when dist folder does not exist in build script

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,7 +8,11 @@ import ts from 'typescript';
 const DIR = './dist';
 
 // Delete and recreate the output directory.
-rmdirSync(DIR, { recursive: true });
+try {
+  rmdirSync(DIR, { recursive: true });
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error;
+}
 mkdirSync(DIR);
 
 // Read the TypeScript config file.


### PR DESCRIPTION
The build script currently fails with `Error: ENOENT: no such file or directory, stat './dist'` the first time anyone clones this repo and runs `npm run build`.

This happens because the `dist` folder does not exist yet, so `rmdirSync(DIR, { recursive: true });` can't remove it.

To reproduce:

```
rm -rf dist
npm run build
```

This is fixed by ignoring the `ENOENT` error.