### PR TITLE
fix: add missing type declarations in conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.cjs",
   "type": "module",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.mjs",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
Types should be present in conditional exports. TypeScript with configured module resolution `NodeNext` doesn't look back to `package.types` field.