### PR TITLE
format ms into full days, hours, minutes, seconds, milliseconds

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -136,7 +136,7 @@ describe('ms(long string)', () => {
   });
 });
 
-// numbers
+// numbers, long format
 
 describe('ms(number, { long: true })', () => {
   it('should not throw an error', () => {
@@ -195,6 +195,177 @@ describe('ms(number, { long: true })', () => {
     expect(ms(234234234, { long: true })).toBe('3 days');
 
     expect(ms(-234234234, { long: true })).toBe('-3 days');
+  });
+});
+
+// numbers all units
+
+describe('ms(number, { allUnits: true })', () => {
+  it('should not throw an error', () => {
+    expect(() => {
+      ms(500, { long: true, allUnits: true });
+    }).not.toThrowError();
+  });
+
+  it('should support milliseconds', () => {
+    expect(ms(500, { long: true, allUnits: true })).toBe('500 ms');
+    expect(ms(500, { long: false, allUnits: true })).toBe('500ms');
+    expect(ms(-500, { long: true, allUnits: true })).toBe('-500 ms');
+    expect(ms(-500, { long: false, allUnits: true })).toBe('-500ms');
+  });
+
+  it('should support seconds', () => {
+    expect(ms(1000, { long: true, allUnits: true })).toBe('1 second 0 ms');
+    expect(ms(1200, { long: true, allUnits: true })).toBe('1 second 200 ms');
+    expect(ms(10000, { long: true, allUnits: true })).toBe('10 seconds 0 ms');
+
+    expect(ms(-1000, { long: true, allUnits: true })).toBe('-1 second 0 ms');
+    expect(ms(-1200, { long: true, allUnits: true })).toBe('-1 second 200 ms');
+    expect(ms(-10000, { long: true, allUnits: true })).toBe('-10 seconds 0 ms');
+
+    expect(ms(1000, { long: false, allUnits: true })).toBe('1s0ms');
+    expect(ms(1200, { long: false, allUnits: true })).toBe('1s200ms');
+    expect(ms(10000, { long: false, allUnits: true })).toBe('10s0ms');
+
+    expect(ms(-1000, { long: false, allUnits: true })).toBe('-1s0ms');
+    expect(ms(-1200, { long: false, allUnits: true })).toBe('-1s200ms');
+    expect(ms(-10000, { long: false, allUnits: true })).toBe('-10s0ms');
+  });
+
+  it('should support minutes', () => {
+    expect(ms(60 * 1000, { long: true, allUnits: true })).toBe(
+      '1 minute 0 seconds 0 ms',
+    );
+    expect(ms(60 * 1200, { long: true, allUnits: true })).toBe(
+      '1 minute 12 seconds 0 ms',
+    );
+    expect(ms(60 * 10000, { long: true, allUnits: true })).toBe(
+      '10 minutes 0 seconds 0 ms',
+    );
+
+    expect(ms(-1 * 60 * 1000, { long: true, allUnits: true })).toBe(
+      '-1 minute 0 seconds 0 ms',
+    );
+    expect(ms(-1 * 60 * 1200, { long: true, allUnits: true })).toBe(
+      '-1 minute 12 seconds 0 ms',
+    );
+    expect(ms(-1 * 60 * 10000, { long: true, allUnits: true })).toBe(
+      '-10 minutes 0 seconds 0 ms',
+    );
+
+    expect(ms(60 * 1000, { long: false, allUnits: true })).toBe('1m0s0ms');
+    expect(ms(60 * 1200, { long: false, allUnits: true })).toBe('1m12s0ms');
+    expect(ms(60 * 10000, { long: false, allUnits: true })).toBe('10m0s0ms');
+
+    expect(ms(-1 * 60 * 1000, { long: false, allUnits: true })).toBe(
+      '-1m0s0ms',
+    );
+    expect(ms(-1 * 60 * 1200, { long: false, allUnits: true })).toBe(
+      '-1m12s0ms',
+    );
+    expect(ms(-1 * 60 * 10000, { long: false, allUnits: true })).toBe(
+      '-10m0s0ms',
+    );
+  });
+
+  it('should support hours', () => {
+    expect(ms(60 * 60 * 1000, { long: true, allUnits: true })).toBe(
+      '1 hour 0 minutes 0 seconds 0 ms',
+    );
+    expect(ms(60 * 60 * 1200, { long: true, allUnits: true })).toBe(
+      '1 hour 12 minutes 0 seconds 0 ms',
+    );
+    expect(ms(60 * 60 * 10000, { long: true, allUnits: true })).toBe(
+      '10 hours 0 minutes 0 seconds 0 ms',
+    );
+
+    expect(ms(-1 * 60 * 60 * 1000, { long: true, allUnits: true })).toBe(
+      '-1 hour 0 minutes 0 seconds 0 ms',
+    );
+    expect(ms(-1 * 60 * 60 * 1200, { long: true, allUnits: true })).toBe(
+      '-1 hour 12 minutes 0 seconds 0 ms',
+    );
+    expect(ms(-1 * 60 * 60 * 10000, { long: true, allUnits: true })).toBe(
+      '-10 hours 0 minutes 0 seconds 0 ms',
+    );
+
+    expect(ms(60 * 60 * 1000, { long: false, allUnits: true })).toBe(
+      '1h0m0s0ms',
+    );
+    expect(ms(60 * 60 * 1200, { long: false, allUnits: true })).toBe(
+      '1h12m0s0ms',
+    );
+    expect(ms(60 * 60 * 10000, { long: false, allUnits: true })).toBe(
+      '10h0m0s0ms',
+    );
+
+    expect(ms(-1 * 60 * 60 * 1000, { long: false, allUnits: true })).toBe(
+      '-1h0m0s0ms',
+    );
+    expect(ms(-1 * 60 * 60 * 1200, { long: false, allUnits: true })).toBe(
+      '-1h12m0s0ms',
+    );
+    expect(ms(-1 * 60 * 60 * 10000, { long: false, allUnits: true })).toBe(
+      '-10h0m0s0ms',
+    );
+  });
+
+  it('should support days', () => {
+    expect(ms(24 * 60 * 60 * 1000, { long: true, allUnits: true })).toBe(
+      '1 day 0 hours 0 minutes 0 seconds 0 ms',
+    );
+    expect(ms(24 * 60 * 60 * 1200, { long: true, allUnits: true })).toBe(
+      '1 day 4 hours 48 minutes 0 seconds 0 ms',
+    );
+    expect(ms(24 * 60 * 60 * 10000, { long: true, allUnits: true })).toBe(
+      '10 days 0 hours 0 minutes 0 seconds 0 ms',
+    );
+
+    expect(ms(-1 * 24 * 60 * 60 * 1000, { long: true, allUnits: true })).toBe(
+      '-1 day 0 hours 0 minutes 0 seconds 0 ms',
+    );
+    expect(ms(-1 * 24 * 60 * 60 * 1200, { long: true, allUnits: true })).toBe(
+      '-1 day 4 hours 48 minutes 0 seconds 0 ms',
+    );
+    expect(ms(-1 * 24 * 60 * 60 * 10000, { long: true, allUnits: true })).toBe(
+      '-10 days 0 hours 0 minutes 0 seconds 0 ms',
+    );
+
+    expect(ms(24 * 60 * 60 * 1000, { long: false, allUnits: true })).toBe(
+      '1d0h0m0s0ms',
+    );
+    expect(ms(24 * 60 * 60 * 1200, { long: false, allUnits: true })).toBe(
+      '1d4h48m0s0ms',
+    );
+    expect(ms(24 * 60 * 60 * 10000, { long: false, allUnits: true })).toBe(
+      '10d0h0m0s0ms',
+    );
+
+    expect(ms(-1 * 24 * 60 * 60 * 1000, { long: false, allUnits: true })).toBe(
+      '-1d0h0m0s0ms',
+    );
+    expect(ms(-1 * 24 * 60 * 60 * 1200, { long: false, allUnits: true })).toBe(
+      '-1d4h48m0s0ms',
+    );
+    expect(ms(-1 * 24 * 60 * 60 * 10000, { long: false, allUnits: true })).toBe(
+      '-10d0h0m0s0ms',
+    );
+  });
+
+  it('should be exact', () => {
+    expect(ms(234234234, { long: true, allUnits: true })).toBe(
+      '2 days 17 hours 3 minutes 54 seconds 234 ms',
+    );
+    expect(ms(-234234234, { long: true, allUnits: true })).toBe(
+      '-2 days 17 hours 3 minutes 54 seconds 234 ms',
+    );
+
+    expect(ms(234234234, { long: false, allUnits: true })).toBe(
+      '2d17h3m54s234ms',
+    );
+    expect(ms(-234234234, { long: false, allUnits: true })).toBe(
+      '-2d17h3m54s234ms',
+    );
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ interface Options {
    * Set to `true` to use verbose formatting. Defaults to `false`.
    */
   long?: boolean;
+  /**
+   * Set to `true` to include days, hours, minutes, seconds, and milliseconds in formatting output.
+   * Defaults to `false`.
+   */
+  allUnits?: boolean;
 }
 
 /**
@@ -67,7 +72,11 @@ function msFn(value: StringValue | number, options?: Options): number | string {
     if (typeof value === 'string' && value.length > 0) {
       return parse(value);
     } else if (typeof value === 'number' && isFinite(value)) {
-      return options?.long ? fmtLong(value) : fmtShort(value);
+      if (options?.allUnits) {
+        return options.long ? fmtLongAllUnits(value) : fmtShortAllUnits(value);
+      } 
+        return options?.long ? fmtLong(value) : fmtShort(value);
+      
     }
     throw new Error('Value is not a string or number.');
   } catch (error) {
@@ -172,23 +181,69 @@ function fmtShort(ms: number): StringValue {
 }
 
 /**
+ * Short format in days, hours, minutes, seconds, milliseconds for `ms`.
+ */
+function fmtShortAllUnits(ms: number): string {
+  const msAbs = Math.abs(ms);
+  const parts: string[] = [];
+  if (msAbs >= d) {
+    parts.push(`${Math.floor(msAbs / d)}d`);
+  }
+  if (msAbs >= h) {
+    parts.push(`${Math.floor((msAbs % d) / h)}h`);
+  }
+  if (msAbs >= m) {
+    parts.push(`${Math.floor((msAbs % h) / m)}m`);
+  }
+  if (msAbs >= s) {
+    parts.push(`${Math.floor((msAbs % m) / s)}s`);
+  }
+  parts.push(`${msAbs % s}ms`);
+  const sign = ms < 0 ? '-' : '';
+  return sign + parts.join('');
+}
+
+/**
  * Long format for `ms`.
  */
 function fmtLong(ms: number): StringValue {
   const msAbs = Math.abs(ms);
   if (msAbs >= d) {
-    return plural(ms, msAbs, d, 'day');
+    return plural(ms, msAbs, d, 'day', true);
   }
   if (msAbs >= h) {
-    return plural(ms, msAbs, h, 'hour');
+    return plural(ms, msAbs, h, 'hour', true);
   }
   if (msAbs >= m) {
-    return plural(ms, msAbs, m, 'minute');
+    return plural(ms, msAbs, m, 'minute', true);
   }
   if (msAbs >= s) {
-    return plural(ms, msAbs, s, 'second');
+    return plural(ms, msAbs, s, 'second', true);
   }
   return `${ms} ms`;
+}
+
+/**
+ * Long format including days, hours, minutes, seconds, and milliseconds for `ms`.
+ */
+function fmtLongAllUnits(ms: number): string {
+  const msAbs = Math.abs(ms);
+  const parts: string[] = [];
+  if (msAbs >= d) {
+    parts.push(plural(msAbs, msAbs, d, 'day', false));
+  }
+  if (msAbs >= h) {
+    parts.push(plural(msAbs % d, msAbs % d, h, 'hour', false));
+  }
+  if (msAbs >= m) {
+    parts.push(plural(msAbs % h, msAbs % h, m, 'minute', false));
+  }
+  if (msAbs >= s) {
+    parts.push(plural(msAbs % m, msAbs % m, s, 'second', false));
+  }
+  parts.push(`${msAbs % s} ms`);
+  const sign = ms < 0 ? '-' : '';
+  return sign + parts.join(' ');
 }
 
 /**
@@ -199,9 +254,12 @@ function plural(
   msAbs: number,
   n: number,
   name: string,
+  round: boolean,
 ): StringValue {
-  const isPlural = msAbs >= n * 1.5;
-  return `${Math.round(ms / n)} ${name}${isPlural ? 's' : ''}` as StringValue;
+  const isPlural = msAbs >= n * 1.5 || msAbs < n;
+  return `${round ? Math.round(ms / n) : Math.floor(ms / n)} ${name}${
+    isPlural ? 's' : ''
+  }` as StringValue;
 }
 
 /**


### PR DESCRIPTION
We want our tools to be able to display exact times instead of rounded times. This pull request adds a new option, `allUnits`, that includes days, hours, minutes, seconds, and milliseconds in formatted output.

I am open to alternative naming or organization! I just want to be able to render exact build times:

![CleanShot 2023-04-08 at 15 16 50@2x](https://user-images.githubusercontent.com/56944708/231598848-48d23688-2ec7-41a2-a706-bcf2b1ab1c56.png)
