### PR TITLE
Add support for microseconds and nanoseconds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,15 @@ ms('100')     // 100
 ms('-3 days') // -259200000
 ms('-1h')     // -3600000
 ms('-200')    // -200
+ms('23μs')    // 0.023
+ms('386ns')   // 0.000386
 ```
 
 ### Convert from Milliseconds
 
 <!-- prettier-ignore -->
 ```js
+ms(2e-2)              // "20μs"
 ms(60000)             // "1m"
 ms(2 * 60000)         // "2m"
 ms(-3 * 60000)        // "-3m"
@@ -37,6 +40,7 @@ ms(ms('10 hours'))    // "10h"
 
 <!-- prettier-ignore -->
 ```js
+ms(2e-2, { long: true })              // "20 microseconds"
 ms(60000, { long: true })             // "1 minute"
 ms(2 * 60000, { long: true })         // "2 minutes"
 ms(-3 * 60000, { long: true })        // "-3 minutes"

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -10,9 +10,9 @@ describe('format(number, { long: true })', () => {
   });
 
   it('should support milliseconds', () => {
-    expect(format(500, { long: true })).toBe('500 ms');
+    expect(format(500, { long: true })).toBe('500 milliseconds');
 
-    expect(format(-500, { long: true })).toBe('-500 ms');
+    expect(format(-500, { long: true })).toBe('-500 milliseconds');
   });
 
   it('should support seconds', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,6 +35,14 @@ describe('ms(string)', () => {
     expect(ms('100ms')).toBe(100);
   });
 
+  it('should convert μs to ms', () => {
+    expect(ms('1μs')).toBe(0.001);
+  });
+
+  it('should convert ns to ms', () => {
+    expect(ms('1ns')).toBe(0.000001);
+  });
+
   it('should convert y to ms', () => {
     expect(ms('1y')).toBe(31557600000);
   });
@@ -134,6 +142,14 @@ describe('ms(long string)', () => {
   it('should work with negative decimals starting with "."', () => {
     expect(ms('-.5 hr')).toBe(-1800000);
   });
+
+  it('should convert nanoseconds to ms', () => {
+    expect(ms('42 nanoseconds')).toBe(4.2e-5);
+  });
+
+  it('should convert microseconds to ms', () => {
+    expect(ms('66 microseconds')).toBe(0.066);
+  });
 });
 
 // numbers
@@ -145,10 +161,20 @@ describe('ms(number, { long: true })', () => {
     }).not.toThrowError();
   });
 
-  it('should support milliseconds', () => {
-    expect(ms(500, { long: true })).toBe('500 ms');
+  it('should support nanoseconds', () => {
+    expect(ms(998e-6, { long: true })).toBe('998 nanoseconds');
+  });
 
-    expect(ms(-500, { long: true })).toBe('-500 ms');
+  it('should support microseconds', () => {
+    expect(ms(1e-3, { long: true })).toBe('1 microsecond');
+    expect(ms(12e-4, { long: true })).toBe('1 microsecond');
+    expect(ms(10e-3, { long: true })).toBe('10 microseconds');
+  });
+
+  it('should support milliseconds', () => {
+    expect(ms(500, { long: true })).toBe('500 milliseconds');
+
+    expect(ms(-500, { long: true })).toBe('-500 milliseconds');
   });
 
   it('should support seconds', () => {
@@ -205,6 +231,14 @@ describe('ms(number)', () => {
     expect(() => {
       ms(500);
     }).not.toThrowError();
+  });
+
+  it('should support microseconds', () => {
+    expect(ms(13e-3)).toBe('13μs');
+  });
+
+  it('should support nanoseconds', () => {
+    expect(ms(500e-6)).toBe('500ns');
   });
 
   it('should support milliseconds', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 // Helpers.
+const ns = 1e-6;
+const μs = 1e-3;
 const s = 1000;
 const m = s * 60;
 const h = m * 60;
@@ -37,7 +39,19 @@ type Unit =
   | 'Millisecond'
   | 'Msecs'
   | 'Msec'
-  | 'Ms';
+  | 'Ms'
+  | 'microseconds'
+  | 'microsecond'
+  | 'micros'
+  | 'micro'
+  | 'μs'
+  | 'nanoseconds'
+  | 'nanosecond'
+  | 'nanos'
+  | 'nano'
+  | 'nsecs'
+  | 'nsec'
+  | 'ns';
 
 type UnitAnyCase = Unit | Uppercase<Unit> | Lowercase<Unit>;
 
@@ -92,7 +106,7 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?(?:\d+)?\.?\d+) *(?<type>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
+    /^(?<value>-?(?:\d+)?\.?\d+) *(?<type>nanoseconds?|nanos?|nsecs?|ns|microseconds?|micros?|μs|milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
       str,
     );
   // Named capture groups need to be manually typed today.
@@ -142,6 +156,20 @@ export function parse(str: string): number {
     case 'msec':
     case 'ms':
       return n;
+    case 'microseconds':
+    case 'microsecond':
+    case 'micros':
+    case 'micro':
+    case 'μs':
+      return n * μs;
+    case 'nanoseconds':
+    case 'nanosecond':
+    case 'nanos':
+    case 'nano':
+    case 'nsecs':
+    case 'nsec':
+    case 'ns':
+      return n * ns;
     default:
       // This should never occur.
       throw new Error(
@@ -181,7 +209,13 @@ function fmtShort(ms: number): StringValue {
   if (msAbs >= s) {
     return `${Math.round(ms / s)}s`;
   }
-  return `${ms}ms`;
+  if (msAbs >= 1) {
+    return `${ms}ms`;
+  }
+  if (msAbs >= μs) {
+    return `${Math.round(ms / μs)}μs`;
+  }
+  return `${Math.round(ms / ns)}ns`;
 }
 
 /**
@@ -201,7 +235,14 @@ function fmtLong(ms: number): StringValue {
   if (msAbs >= s) {
     return plural(ms, msAbs, s, 'second');
   }
-  return `${ms} ms`;
+  if (msAbs >= 1) {
+    return plural(ms, msAbs, 1, 'millisecond');
+  }
+  if (msAbs >= μs) {
+    return plural(ms, msAbs, μs, 'microsecond');
+  }
+
+  return plural(ms, msAbs, ns, 'nanosecond');
 }
 
 /**


### PR DESCRIPTION
This brings back https://github.com/vercel/ms/pull/87 since it'd be nice to have micro and nano seconds for things like test run timings and more.

Have to say a thank you to @scottinet for the original. If this is unwanted, then close accordingly.