### PR TITLE
fix CI: run on `main`, not `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,9 +2,9 @@ name: Quality
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   prettier:


### PR DESCRIPTION
Looks like the default branch for this project was changed from `master` to `main` but the CI wasn't updated, which causes it not to ever run.  This PR fixes the branch resolution.