### PR TITLE
adds week format to fmtShort and fmtLong

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -47,13 +47,27 @@ describe('format(number, { long: true })', () => {
   });
 
   it('should support days', () => {
-    expect(format(24 * 60 * 60 * 1000, { long: true })).toBe('1 day');
-    expect(format(24 * 60 * 60 * 1200, { long: true })).toBe('1 day');
-    expect(format(24 * 60 * 60 * 10000, { long: true })).toBe('10 days');
+    expect(format(1 * 24 * 60 * 60 * 1000, { long: true })).toBe('1 day');
+    expect(format(1 * 24 * 60 * 60 * 1200, { long: true })).toBe('1 day');
+    expect(format(6 * 24 * 60 * 60 * 1000, { long: true })).toBe('6 days');
 
-    expect(format(-1 * 24 * 60 * 60 * 1000, { long: true })).toBe('-1 day');
-    expect(format(-1 * 24 * 60 * 60 * 1200, { long: true })).toBe('-1 day');
-    expect(format(-1 * 24 * 60 * 60 * 10000, { long: true })).toBe('-10 days');
+    expect(format(-1 * 1 * 24 * 60 * 60 * 1000, { long: true })).toBe('-1 day');
+    expect(format(-1 * 1 * 24 * 60 * 60 * 1200, { long: true })).toBe('-1 day');
+    expect(format(-1 * 6 * 24 * 60 * 60 * 1000, { long: true })).toBe(
+      '-6 days',
+    );
+  });
+
+  it('should support weeks', () => {
+    expect(format(1 * 7 * 24 * 60 * 60 * 1000, { long: true })).toBe('1 week');
+    expect(format(2 * 7 * 24 * 60 * 60 * 1000, { long: true })).toBe('2 weeks');
+
+    expect(format(-1 * 1 * 7 * 24 * 60 * 60 * 1000, { long: true })).toBe(
+      '-1 week',
+    );
+    expect(format(-1 * 2 * 7 * 24 * 60 * 60 * 1000, { long: true })).toBe(
+      '-2 weeks',
+    );
   });
 
   it('should support months', () => {
@@ -148,10 +162,18 @@ describe('format(number)', () => {
 
   it('should support days', () => {
     expect(format(24 * 60 * 60 * 1000)).toBe('1d');
-    expect(format(24 * 60 * 60 * 10000)).toBe('10d');
+    expect(format(24 * 60 * 60 * 6000)).toBe('6d');
 
     expect(format(-1 * 24 * 60 * 60 * 1000)).toBe('-1d');
-    expect(format(-1 * 24 * 60 * 60 * 10000)).toBe('-10d');
+    expect(format(-1 * 24 * 60 * 60 * 6000)).toBe('-6d');
+  });
+
+  it('should support weeks', () => {
+    expect(format(1 * 7 * 24 * 60 * 60 * 1000)).toBe('1w');
+    expect(format(2 * 7 * 24 * 60 * 60 * 1000)).toBe('2w');
+
+    expect(format(-1 * 1 * 7 * 24 * 60 * 60 * 1000)).toBe('-1w');
+    expect(format(-1 * 2 * 7 * 24 * 60 * 60 * 1000)).toBe('-2w');
   });
 
   it('should support months', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -183,13 +183,25 @@ describe('ms(number, { long: true })', () => {
   });
 
   it('should support days', () => {
-    expect(ms(24 * 60 * 60 * 1000, { long: true })).toBe('1 day');
-    expect(ms(24 * 60 * 60 * 1200, { long: true })).toBe('1 day');
-    expect(ms(24 * 60 * 60 * 10000, { long: true })).toBe('10 days');
+    expect(ms(1 * 24 * 60 * 60 * 1000, { long: true })).toBe('1 day');
+    expect(ms(1 * 24 * 60 * 60 * 1200, { long: true })).toBe('1 day');
+    expect(ms(6 * 24 * 60 * 60 * 1000, { long: true })).toBe('6 days');
 
-    expect(ms(-1 * 24 * 60 * 60 * 1000, { long: true })).toBe('-1 day');
-    expect(ms(-1 * 24 * 60 * 60 * 1200, { long: true })).toBe('-1 day');
-    expect(ms(-1 * 24 * 60 * 60 * 10000, { long: true })).toBe('-10 days');
+    expect(ms(-1 * 1 * 24 * 60 * 60 * 1000, { long: true })).toBe('-1 day');
+    expect(ms(-1 * 1 * 24 * 60 * 60 * 1200, { long: true })).toBe('-1 day');
+    expect(ms(-1 * 6 * 24 * 60 * 60 * 1000, { long: true })).toBe('-6 days');
+  });
+
+  it('should support weeks', () => {
+    expect(ms(1 * 7 * 24 * 60 * 60 * 1000, { long: true })).toBe('1 week');
+    expect(ms(2 * 7 * 24 * 60 * 60 * 1000, { long: true })).toBe('2 weeks');
+
+    expect(ms(-1 * 1 * 7 * 24 * 60 * 60 * 1000, { long: true })).toBe(
+      '-1 week',
+    );
+    expect(ms(-1 * 2 * 7 * 24 * 60 * 60 * 1000, { long: true })).toBe(
+      '-2 weeks',
+    );
   });
 
   it('should support months', () => {
@@ -276,10 +288,18 @@ describe('ms(number)', () => {
 
   it('should support days', () => {
     expect(ms(24 * 60 * 60 * 1000)).toBe('1d');
-    expect(ms(24 * 60 * 60 * 10000)).toBe('10d');
+    expect(ms(24 * 60 * 60 * 6000)).toBe('6d');
 
     expect(ms(-1 * 24 * 60 * 60 * 1000)).toBe('-1d');
-    expect(ms(-1 * 24 * 60 * 60 * 10000)).toBe('-10d');
+    expect(ms(-1 * 24 * 60 * 60 * 6000)).toBe('-6d');
+  });
+
+  it('should support weeks', () => {
+    expect(ms(1 * 7 * 24 * 60 * 60 * 1000)).toBe('1w');
+    expect(ms(2 * 7 * 24 * 60 * 60 * 1000)).toBe('2w');
+
+    expect(ms(-1 * 1 * 7 * 24 * 60 * 60 * 1000)).toBe('-1w');
+    expect(ms(-1 * 2 * 7 * 24 * 60 * 60 * 1000)).toBe('-2w');
   });
 
   it('should support months', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,9 @@ function fmtShort(ms: number): StringValue {
   if (msAbs >= mo) {
     return `${Math.round(ms / mo)}mo`;
   }
+  if (msAbs >= w) {
+    return `${Math.round(ms / w)}w`;
+  }
   if (msAbs >= d) {
     return `${Math.round(ms / d)}d`;
   }
@@ -193,6 +196,9 @@ function fmtLong(ms: number): StringValue {
   }
   if (msAbs >= mo) {
     return plural(ms, msAbs, mo, 'month');
+  }
+  if (msAbs >= w) {
+    return plural(ms, msAbs, w, 'week');
   }
   if (msAbs >= d) {
     return plural(ms, msAbs, d, 'day');


### PR DESCRIPTION
this PR is an expansion pack on https://github.com/vercel/ms/pull/198 that finishes the swing and unifies what formats we accept and what formats we output.

The reason I think we should make this change is actually justified in our current readme:

```ts
ms(ms('10h')) // "10h"
```

However, if you do

```ts
ms(ms('1w')) // "7d"
```

it exposes the inconsistency.

I think it's a net improvement.  There are other PRs and issues open (e.g. https://github.com/vercel/ms/issues/142) that address the concern of "when to move to the next unit" and I think we should handle those with a separate option, but otherwise stay consistent in what we accept and output by default.  This PR (and #198) makes that a reality.