### PR TITLE
adds months support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,13 +44,14 @@ ms(ms('10 hours'), { long: true })    // "10 hours"
 
 ```ts
 type Years = 'years' | 'year' | 'yrs' | 'yr' | 'y'
+type Months = 'months' | 'month' | 'mo'
 type Weeks = 'weeks' | 'week' | 'w'
 type Days = 'days' | 'day' | 'd'
 type Hours = 'hours' | 'hour' | 'hrs' | 'hr' | 'h'
 type Minutes = 'minutes' | 'minute' | 'mins' | 'min' | 'm'
 type Seconds = 'seconds' | 'second' | 'secs' | 'sec' | 's'
 type Milliseconds = 'milliseconds' | 'millisecond' | 'msecs' | 'msec' | 'ms'
-type Unit = Years | Weeks | Days | Hours | Minutes | Seconds | Milliseconds
+type Unit = Years | Months | Weeks | Days | Hours | Minutes | Seconds | Milliseconds
 ```
 
 These formats can be lowercase (`minutes`), uppercase (`MINUTES`), or capitalized (`Minutes`). There can be a space (`2 minutes`) or not (`2minutes`).

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -56,6 +56,50 @@ describe('format(number, { long: true })', () => {
     expect(format(-1 * 24 * 60 * 60 * 10000, { long: true })).toBe('-10 days');
   });
 
+  it('should support months', () => {
+    expect(format(30.436875 * 24 * 60 * 60 * 1000, { long: true })).toBe(
+      '1 month',
+    );
+    expect(format(30.436875 * 24 * 60 * 60 * 1200, { long: true })).toBe(
+      '1 month',
+    );
+    expect(format(30.436875 * 24 * 60 * 60 * 10000, { long: true })).toBe(
+      '10 months',
+    );
+
+    expect(format(-1 * 30.436875 * 24 * 60 * 60 * 1000, { long: true })).toBe(
+      '-1 month',
+    );
+    expect(format(-1 * 30.436875 * 24 * 60 * 60 * 1200, { long: true })).toBe(
+      '-1 month',
+    );
+    expect(format(-1 * 30.436875 * 24 * 60 * 60 * 10000, { long: true })).toBe(
+      '-10 months',
+    );
+  });
+
+  it('should support years', () => {
+    expect(format(365.2425 * 24 * 60 * 60 * 1000 + 1, { long: true })).toBe(
+      '1 year',
+    );
+    expect(format(365.2425 * 24 * 60 * 60 * 1200 + 1, { long: true })).toBe(
+      '1 year',
+    );
+    expect(format(365.2425 * 24 * 60 * 60 * 10000 + 1, { long: true })).toBe(
+      '10 years',
+    );
+
+    expect(
+      format(-1 * 365.2425 * 24 * 60 * 60 * 1000 - 1, { long: true }),
+    ).toBe('-1 year');
+    expect(
+      format(-1 * 365.2425 * 24 * 60 * 60 * 1200 - 1, { long: true }),
+    ).toBe('-1 year');
+    expect(
+      format(-1 * 365.2425 * 24 * 60 * 60 * 10000 - 1, { long: true }),
+    ).toBe('-10 years');
+  });
+
   it('should round', () => {
     expect(format(234234234, { long: true })).toBe('3 days');
 
@@ -108,6 +152,26 @@ describe('format(number)', () => {
 
     expect(format(-1 * 24 * 60 * 60 * 1000)).toBe('-1d');
     expect(format(-1 * 24 * 60 * 60 * 10000)).toBe('-10d');
+  });
+
+  it('should support months', () => {
+    expect(format(30.436875 * 24 * 60 * 60 * 1000)).toBe('1mo');
+    expect(format(30.436875 * 24 * 60 * 60 * 1200)).toBe('1mo');
+    expect(format(30.436875 * 24 * 60 * 60 * 10000)).toBe('10mo');
+
+    expect(format(-1 * 30.436875 * 24 * 60 * 60 * 1000)).toBe('-1mo');
+    expect(format(-1 * 30.436875 * 24 * 60 * 60 * 1200)).toBe('-1mo');
+    expect(format(-1 * 30.436875 * 24 * 60 * 60 * 10000)).toBe('-10mo');
+  });
+
+  it('should support years', () => {
+    expect(format(365.2425 * 24 * 60 * 60 * 1000 + 1)).toBe('1y');
+    expect(format(365.2425 * 24 * 60 * 60 * 1200 + 1)).toBe('1y');
+    expect(format(365.2425 * 24 * 60 * 60 * 10000 + 1)).toBe('10y');
+
+    expect(format(-1 * 365.2425 * 24 * 60 * 60 * 1000 - 1)).toBe('-1y');
+    expect(format(-1 * 365.2425 * 24 * 60 * 60 * 1200 - 1)).toBe('-1y');
+    expect(format(-1 * 365.2425 * 24 * 60 * 60 * 10000 - 1)).toBe('-10y');
   });
 
   it('should round', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,7 +37,7 @@ describe('ms(string)', () => {
   });
 
   it('should convert y to ms', () => {
-    expect(ms('1y')).toBe(31557600000);
+    expect(ms('1y')).toBe(31556952000);
   });
 
   it('should work with decimals', () => {
@@ -117,7 +117,7 @@ describe('ms(long string)', () => {
   });
 
   it('should convert years to ms', () => {
-    expect(ms('1 year')).toBe(31557600000);
+    expect(ms('1 year')).toBe(31556952000);
   });
 
   it('should work with decimals', () => {
@@ -192,6 +192,46 @@ describe('ms(number, { long: true })', () => {
     expect(ms(-1 * 24 * 60 * 60 * 10000, { long: true })).toBe('-10 days');
   });
 
+  it('should support months', () => {
+    expect(ms(30.436875 * 24 * 60 * 60 * 1000, { long: true })).toBe('1 month');
+    expect(ms(30.436875 * 24 * 60 * 60 * 1200, { long: true })).toBe('1 month');
+    expect(ms(30.436875 * 24 * 60 * 60 * 10000, { long: true })).toBe(
+      '10 months',
+    );
+
+    expect(ms(-1 * 30.436875 * 24 * 60 * 60 * 1000, { long: true })).toBe(
+      '-1 month',
+    );
+    expect(ms(-1 * 30.436875 * 24 * 60 * 60 * 1200, { long: true })).toBe(
+      '-1 month',
+    );
+    expect(ms(-1 * 30.436875 * 24 * 60 * 60 * 10000, { long: true })).toBe(
+      '-10 months',
+    );
+  });
+
+  it('should support years', () => {
+    expect(ms(365.2425 * 24 * 60 * 60 * 1000 + 1, { long: true })).toBe(
+      '1 year',
+    );
+    expect(ms(365.2425 * 24 * 60 * 60 * 1200 + 1, { long: true })).toBe(
+      '1 year',
+    );
+    expect(ms(365.2425 * 24 * 60 * 60 * 10000 + 1, { long: true })).toBe(
+      '10 years',
+    );
+
+    expect(ms(-1 * 365.2425 * 24 * 60 * 60 * 1000 - 1, { long: true })).toBe(
+      '-1 year',
+    );
+    expect(ms(-1 * 365.2425 * 24 * 60 * 60 * 1200 - 1, { long: true })).toBe(
+      '-1 year',
+    );
+    expect(ms(-1 * 365.2425 * 24 * 60 * 60 * 10000 - 1, { long: true })).toBe(
+      '-10 years',
+    );
+  });
+
   it('should round', () => {
     expect(ms(234234234, { long: true })).toBe('3 days');
 
@@ -244,6 +284,26 @@ describe('ms(number)', () => {
 
     expect(ms(-1 * 24 * 60 * 60 * 1000)).toBe('-1d');
     expect(ms(-1 * 24 * 60 * 60 * 10000)).toBe('-10d');
+  });
+
+  it('should support months', () => {
+    expect(ms(30.436875 * 24 * 60 * 60 * 1000)).toBe('1mo');
+    expect(ms(30.436875 * 24 * 60 * 60 * 1200)).toBe('1mo');
+    expect(ms(30.436875 * 24 * 60 * 60 * 10000)).toBe('10mo');
+
+    expect(ms(-1 * 30.436875 * 24 * 60 * 60 * 1000)).toBe('-1mo');
+    expect(ms(-1 * 30.436875 * 24 * 60 * 60 * 1200)).toBe('-1mo');
+    expect(ms(-1 * 30.436875 * 24 * 60 * 60 * 10000)).toBe('-10mo');
+  });
+
+  it('should support years', () => {
+    expect(ms(365.2425 * 24 * 60 * 60 * 1000 + 1)).toBe('1y');
+    expect(ms(365.2425 * 24 * 60 * 60 * 1200 + 1)).toBe('1y');
+    expect(ms(365.2425 * 24 * 60 * 60 * 10000 + 1)).toBe('10y');
+
+    expect(ms(-1 * 365.2425 * 24 * 60 * 60 * 1000 - 1)).toBe('-1y');
+    expect(ms(-1 * 365.2425 * 24 * 60 * 60 * 1200 - 1)).toBe('-1y');
+    expect(ms(-1 * 365.2425 * 24 * 60 * 60 * 10000 - 1)).toBe('-10y');
   });
 
   it('should round', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,28 @@
-// Helpers.
 const s = 1000;
 const m = s * 60;
 const h = m * 60;
 const d = h * 24;
 const w = d * 7;
-const y = d * 365.25;
+const y = d * 365.2425;
+const mo = y / 12;
 
 type Years = 'years' | 'year' | 'yrs' | 'yr' | 'y';
+type Months = 'months' | 'month' | 'mo';
 type Weeks = 'weeks' | 'week' | 'w';
 type Days = 'days' | 'day' | 'd';
 type Hours = 'hours' | 'hour' | 'hrs' | 'hr' | 'h';
 type Minutes = 'minutes' | 'minute' | 'mins' | 'min' | 'm';
 type Seconds = 'seconds' | 'second' | 'secs' | 'sec' | 's';
 type Milliseconds = 'milliseconds' | 'millisecond' | 'msecs' | 'msec' | 'ms';
-type Unit = Years | Weeks | Days | Hours | Minutes | Seconds | Milliseconds;
+type Unit =
+  | Years
+  | Months
+  | Weeks
+  | Days
+  | Hours
+  | Minutes
+  | Seconds
+  | Milliseconds;
 
 type UnitAnyCase = Capitalize<Unit> | Uppercase<Unit> | Unit;
 
@@ -66,7 +75,7 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?(?:\d+)?\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
+    /^(?<value>-?(?:\d+)?\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
       str,
     );
 
@@ -93,6 +102,10 @@ export function parse(str: string): number {
     case 'yr':
     case 'y':
       return n * y;
+    case 'months':
+    case 'month':
+    case 'mo':
+      return n * mo;
     case 'weeks':
     case 'week':
     case 'w':
@@ -149,6 +162,12 @@ export function parseStrict(value: StringValue): number {
  */
 function fmtShort(ms: number): StringValue {
   const msAbs = Math.abs(ms);
+  if (msAbs >= y) {
+    return `${Math.round(ms / y)}y`;
+  }
+  if (msAbs >= mo) {
+    return `${Math.round(ms / mo)}mo`;
+  }
   if (msAbs >= d) {
     return `${Math.round(ms / d)}d`;
   }
@@ -169,6 +188,12 @@ function fmtShort(ms: number): StringValue {
  */
 function fmtLong(ms: number): StringValue {
   const msAbs = Math.abs(ms);
+  if (msAbs >= y) {
+    return plural(ms, msAbs, y, 'year');
+  }
+  if (msAbs >= mo) {
+    return plural(ms, msAbs, mo, 'month');
+  }
   if (msAbs >= d) {
     return plural(ms, msAbs, d, 'day');
   }

--- a/src/parse-strict.test.ts
+++ b/src/parse-strict.test.ts
@@ -36,8 +36,11 @@ describe('parseStrict(string)', () => {
     expect(parseStrict('100ms')).toBe(100);
   });
 
+  it('should convert mo to ms', () => {
+    expect(parseStrict('1mo')).toBe(2629746000);
+  });
   it('should convert y to ms', () => {
-    expect(parseStrict('1y')).toBe(31557600000);
+    expect(parseStrict('1y')).toBe(31556952000);
   });
 
   it('should work with ms', () => {
@@ -59,7 +62,7 @@ describe('parseStrict(string)', () => {
 
   it('should be case-insensitive', () => {
     // @ts-expect-error - we expect the types to fail but JS users can still use this
-    expect(parseStrict('53 YeArS')).toBe(1672552800000);
+    expect(parseStrict('53 YeArS')).toBe(1672518456000);
     // @ts-expect-error - we expect the types to fail but JS users can still use this
     expect(parseStrict('53 WeEkS')).toBe(32054400000);
     // @ts-expect-error - we expect the types to fail but JS users can still use this
@@ -125,8 +128,12 @@ describe('parseStrict(long string)', () => {
     expect(parseStrict('1 week')).toBe(604800000);
   });
 
+  it('should convert months to ms', () => {
+    expect(parseStrict('1 month')).toBe(2629746000);
+  });
+
   it('should convert years to ms', () => {
-    expect(parseStrict('1 year')).toBe(31557600000);
+    expect(parseStrict('1 year')).toBe(31556952000);
   });
 
   it('should work with decimals', () => {

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -37,7 +37,7 @@ describe('parse(string)', () => {
   });
 
   it('should convert y to ms', () => {
-    expect(parse('1y')).toBe(31557600000);
+    expect(parse('1y')).toBe(31556952000);
   });
 
   it('should work with ms', () => {
@@ -55,7 +55,7 @@ describe('parse(string)', () => {
   });
 
   it('should be case-insensitive', () => {
-    expect(parse('53 YeArS')).toBe(1672552800000);
+    expect(parse('53 YeArS')).toBe(1672518456000);
     expect(parse('53 WeEkS')).toBe(32054400000);
     expect(parse('53 DaYS')).toBe(4579200000);
     expect(parse('53 HoUrs')).toBe(190800000);
@@ -117,8 +117,12 @@ describe('parse(long string)', () => {
     expect(parse('1 week')).toBe(604800000);
   });
 
+  it('should convert months to ms', () => {
+    expect(parse('1 month')).toBe(2629746000);
+  });
+
   it('should convert years to ms', () => {
-    expect(parse('1 year')).toBe(31557600000);
+    expect(parse('1 year')).toBe(31556952000);
   });
 
   it('should work with decimals', () => {


### PR DESCRIPTION
closes https://github.com/vercel/ms/issues/57
closes https://github.com/vercel/ms/pull/181

wow! wasn't expecting "how long is a month" to be so complicated!  there is no shortage of hot takes on the internet on this topic with people screaming "you are all morons, it's XYZ-milliseconds!!!", but hey, that's life in the big city!

as I see it, there are 3 options this package could take:

1. use `2592000000` 30 days, since it's a sorta rough-yet-reasonable average
    - `moment.js`: `moment.duration(1, "months").asMilliseconds()`
    - `luxon`: `luxon.Duration.fromObject({ months: 1 }).as('milliseconds')`
1. use `2628000000` 365 days / 12
    - `day.js`: `dayjs.duration(1, "months").asMilliseconds();`
1. use `2629746000` 365.2425 days / 12
    - Spotify, Google Cloud, Twilio, Stripe, PayPal

I'm swayed by the decision the payment processors took.  I can see why they might have, it's the most correct.

> side note:
> I thought it was cute that the upcoming Temporal API as well as `date-fns` sidestep the issue by simply not allowing you to create a duration of a month without a start date (which, then, would have a specific month associated).

# indecision has lead to inaction

Instead of spending the next month (get it? joke? lol) pondering this, let's move forward with the 3rd option.  This has the benefit of not introducing any rounding errors.  The number of milliseconds in 1 month (as defined by this package) will be a twelfth of the milliseconds in 1 year, but without causing any rounding errors if you get into larger timeframes.

----

I, personally, have very much enjoyed reading people's spicy discourse on this topic.  We're all excited about details like this.  That's cool, I embrace that.  But this PR isn't the place.  Please don't argue - instead, if you disagree, bring specific end-user use-cases that will cause breakage from setting this at one particular value.