### PR TITLE
chore(style): revert back to ternary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -227,11 +227,7 @@ export function format(ms: number, options?: Options): string {
     throw new Error('Value provided to ms.format() must be of type number.');
   }
 
-  if (options?.long) {
-    return fmtLong(ms);
-  }
-
-  return fmtShort(ms);
+  return options?.long ? fmtLong(ms) : fmtShort(ms);
 }
 
 /**


### PR DESCRIPTION
This was accidentally changed in https://github.com/vercel/ms/pull/198 (I think merge conflicts)