### PR TITLE
use "nightly" tag instead of "canary" and target 4.x for next major

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           BASE=$(node -p "require('./package.json').version.split('-')[0]")
           DATE=$(date +'%Y%m%d%H%M')
-          CANARY="${BASE}-canary.${DATE}"
+          NIGHTLY="${BASE}-nightly.${DATE}"
 
-          pnpm version --no-git-tag-version "$CANARY"
-          pnpm publish --tag canary --access public --no-git-checks
+          pnpm version --no-git-tag-version "$NIGHTLY"
+          pnpm publish --tag nightly --access public --no-git-checks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Tiny millisecond conversion utility",
   "repository": {
     "type": "git",


### PR DESCRIPTION
closes https://github.com/vercel/ms/issues/260