### PR TITLE
breaking change!: only ship ESM (and drop Node 18)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
         task: [test:nodejs, test:edge]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "type": "git",
     "url": "git+https://github.com/vercel/ms.git"
   },
-  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "type": "git",
     "url": "git+https://github.com/vercel/ms.git"
   },
-  "main": "./dist/index.cjs",
-  "types": "./dist/index.d.cts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
@@ -15,10 +15,7 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "default": "./dist/index.js"
     }
   },
   "sideEffects": false,
@@ -38,7 +35,7 @@
     "lint": "biome lint",
     "format": "biome format",
     "typecheck": "tsc --noEmit",
-    "attw": "pnpm build && attw --pack .",
+    "attw": "pnpm build && attw --pack --profile esm-only .",
     "precommit": "lint-staged",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "sideEffects": false,
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "packageManager": "pnpm@10.14.0-0+sha512.2cd47a0cbf5f1d1de7693a88307a0ede5be94e0d3b34853d800ee775efbea0650cb562b77605ec80bc8d925f5cd27c4dfe8bb04d3a0b76090784c664450d32d6",
   "files": [

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['cjs', 'esm'],
+  format: ['esm'],
   dts: true,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
closes https://github.com/vercel/ms/issues/261

is it happening?  is it finally happening?  are we shipping a library with only ESM?  we must be in the future.