### PR TITLE
Add support for multiple units

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -385,3 +385,24 @@ describe('ms(invalid inputs)', () => {
     }).toThrow();
   });
 });
+
+//multiple units
+describe('ms(multipleunits)', () => {
+  it('should not throw an error, when ms(hasmorethanoneunit)', () => {
+    expect(() => {
+      ms('3y40s');
+    }).not.toThrow();
+    expect(() => {
+      ms('3y 40s');
+    }).not.toThrow();
+    expect(() => {
+      ms('3 y 40 s');
+    }).not.toThrow();
+  });
+
+  it('should convert all values into ms', () => {
+    expect(ms('1 h 45 s')).toBe(3645000);
+    expect(ms('3seconds40s')).toBe(43000);
+    expect(ms('1m1mo1ms')).toBe(2629860001)
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -406,7 +406,7 @@ describe('ms(multipleunits)', () => {
     expect(ms('1m1mo1ms')).toBe(2629860001);
   });
 
-  it('should return NaN if invalid' , () => {
+  it('should return NaN if invalid', () => {
     expect(Number.isNaN(ms('3h2failure'))).toBe(true);
-  })
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -403,6 +403,10 @@ describe('ms(multipleunits)', () => {
   it('should convert all values into ms', () => {
     expect(ms('1 h 45 s')).toBe(3645000);
     expect(ms('3seconds40s')).toBe(43000);
-    expect(ms('1m1mo1ms')).toBe(2629860001)
+    expect(ms('1m1mo1ms')).toBe(2629860001);
   });
+
+  it('should return NaN if invalid' , () => {
+    expect(Number.isNaN(ms('3h2failure'))).toBe(true);
+  })
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,10 @@ type UnitAnyCase = Capitalize<Unit> | Uppercase<Unit> | Unit;
 export type StringValue =
   | `${number}`
   | `${number}${UnitAnyCase}`
-  | `${number} ${UnitAnyCase}`;
+  | `${number} ${UnitAnyCase}`
+  | `${`${number}${Years}` | ``}${`${number}${Months}` | ``}${`${number}${Weeks}` | ``}${`${number}${Days}` | ``}${`${number}${Hours}` | ``}${`${number}${Minutes}` | ``}${`${number}${Seconds}` | ``}${`${number}${Milliseconds}` | `${number}` | ``}`
+  | `${`${number} ${Years}` | ``} ${`${number} ${Months}` | ``} ${`${number} ${Weeks}` | ``} ${`${number} ${Days}` | ``} ${`${number} ${Hours}` | ``} ${`${number} ${Minutes}` | ``} ${`${number} ${Seconds}` | ``} ${`${number} ${Milliseconds}` | `${number}` | ``}`
+  | `${`${number}${Years}` | ``} ${`${number}${Months}` | ``} ${`${number}${Weeks}` | ``} ${`${number}${Days}` | ``} ${`${number}${Hours}` | ``} ${`${number}${Minutes}` | ``} ${`${number}${Seconds}` | ``} ${`${number}${Milliseconds}` | `${number}` | ``}`;
 
 interface Options {
   /**
@@ -164,7 +167,7 @@ export function parseStrict(value: StringValue): number {
 
 function multipleUnits(value: string): number {
   const regEx =
-    /\d*\.?\d+ *(?:milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)/gi;
+    /\d*\.?\d+ *(?:milliseconds?|msecs?|ms|seconds?|secs?|s|months?|mo|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)/gi;
 
   const match = [...value.matchAll(regEx)].flat();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,22 +159,21 @@ export function parseStrict(value: StringValue): number {
 
 /**
  * Parse the given string with multiple time units and return milliseconds.
- * 
+ *
  */
 
 function multipleUnits(value: string): number {
+  const regEx =
+    /\d*\.?\d+ *(?:milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)/gi;
 
-  const splitUnits : string[] = value.split(" ");
-  
+  const match = [...value.matchAll(regEx)].flat();
 
-  //No comprueba si están en orden o repetidos
+  if (match.length === 0) {
+    return NaN;
+  }
 
-  return splitUnits.reduce(
-    (accumulator, unit) => parse(unit) + accumulator, 0,
-  );
-
+  return match.reduce((accumulator, unit) => parse(unit) + accumulator, 0);
 }
-
 
 /**
  * Short format for `ms`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export function parse(str: string): number {
     );
 
   if (!match?.groups) {
-    return NaN;
+    return multipleUnits(str);
   }
 
   // Named capture groups need to be manually typed today.
@@ -156,6 +156,25 @@ export function parse(str: string): number {
 export function parseStrict(value: StringValue): number {
   return parse(value);
 }
+
+/**
+ * Parse the given string with multiple time units and return milliseconds.
+ * 
+ */
+
+function multipleUnits(value: string): number {
+
+  const splitUnits : string[] = value.split(" ");
+  
+
+  //No comprueba si están en orden o repetidos
+
+  return splitUnits.reduce(
+    (accumulator, unit) => parse(unit) + accumulator, 0,
+  );
+
+}
+
 
 /**
  * Short format for `ms`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,6 @@ export function parse(str: string): number {
   if (!match?.groups) {
     return multipleUnits(str);
   }
-  
 
   // Named capture groups need to be manually typed today.
   // https://github.com/microsoft/TypeScript/issues/32098
@@ -148,8 +147,6 @@ export function parse(str: string): number {
         `Unknown unit "${matchUnit}" provided to ms.parse(). value=${JSON.stringify(str)}`,
       );
   }
-
-  
 }
 
 /**
@@ -177,7 +174,7 @@ function multipleUnits(value: string): number {
     /\d*\.?\d+ *(?:milliseconds?|msecs?|ms|seconds?|secs?|s|months?|mo|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)/gi;
 
   const match = [...value.matchAll(regEx)].flat();
-  const unmatchedString = value.replaceAll(regEx , '');
+  const unmatchedString = value.replaceAll(regEx, '');
   const spaceRegEx = /^ *$/;
 
   if (match.length === 0 || spaceRegEx.exec(unmatchedString) === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export function parse(str: string): number {
   if (!match?.groups) {
     return multipleUnits(str);
   }
+  
 
   // Named capture groups need to be manually typed today.
   // https://github.com/microsoft/TypeScript/issues/32098
@@ -147,6 +148,8 @@ export function parse(str: string): number {
         `Unknown unit "${matchUnit}" provided to ms.parse(). value=${JSON.stringify(str)}`,
       );
   }
+
+  
 }
 
 /**
@@ -163,6 +166,10 @@ export function parseStrict(value: StringValue): number {
 /**
  * Parse the given string with multiple time units and return milliseconds.
  *
+ * @param value - A typesafe StringValue comprised of multiple strings to convert
+ * into milliseconds
+ * @returns The sum of all parsed strings value in milliseconds, or `NaN` if the
+ * string can't be parsed
  */
 
 function multipleUnits(value: string): number {
@@ -170,8 +177,10 @@ function multipleUnits(value: string): number {
     /\d*\.?\d+ *(?:milliseconds?|msecs?|ms|seconds?|secs?|s|months?|mo|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)/gi;
 
   const match = [...value.matchAll(regEx)].flat();
+  const unmatchedString = value.replaceAll(regEx , '');
+  const spaceRegEx = /^ *$/;
 
-  if (match.length === 0) {
+  if (match.length === 0 || spaceRegEx.exec(unmatchedString) === null) {
     return NaN;
   }
 

--- a/src/parse-strict.test.ts
+++ b/src/parse-strict.test.ts
@@ -219,3 +219,24 @@ describe('parseStrict(invalid inputs)', () => {
     }).toThrow();
   });
 });
+
+//multiple units
+describe('ms(multipleunits)', () => {
+  it('should not throw an error, when ms(hasmorethanoneunit)', () => {
+    expect(() => {
+      parseStrict('3y40s');
+    }).not.toThrow();
+    expect(() => {
+      parseStrict('3y 40s');
+    }).not.toThrow();
+    expect(() => {
+      parseStrict('3 y 40 s');
+    }).not.toThrow();
+  });
+
+  it('should convert all values into ms', () => {
+    expect(parseStrict('1 h 45 s')).toBe(3645000);
+    expect(parseStrict('3seconds40s')).toBe(43000);
+  });
+
+});

--- a/src/parse-strict.test.ts
+++ b/src/parse-strict.test.ts
@@ -238,5 +238,4 @@ describe('ms(multipleunits)', () => {
     expect(parseStrict('1 h 45 s')).toBe(3645000);
     expect(parseStrict('3seconds40s')).toBe(43000);
   });
-
 });

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -206,3 +206,24 @@ describe('parse(invalid inputs)', () => {
     }).toThrow();
   });
 });
+
+//multiple units
+describe('ms(multipleunits)', () => {
+  it('should not throw an error, when ms(hasmorethanoneunit)', () => {
+    expect(() => {
+      parse('3y40s');
+    }).not.toThrow();
+    expect(() => {
+      parse('3y 40s');
+    }).not.toThrow();
+    expect(() => {
+      parse('3 y 40 s');
+    }).not.toThrow();
+  });
+
+  it('should convert all values into ms', () => {
+    expect(parse('1 h 45 s')).toBe(3645000);
+    expect(parse('3seconds40s')).toBe(43000);
+  });
+
+});

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -226,7 +226,7 @@ describe('ms(multipleunits)', () => {
     expect(parse('3seconds40s')).toBe(43000);
   });
 
-  it('should return NaN if invalid' , () => {
-      expect(Number.isNaN(parse('3h2failure'))).toBe(true);
-    })
+  it('should return NaN if invalid', () => {
+    expect(Number.isNaN(parse('3h2failure'))).toBe(true);
+  });
 });

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -226,4 +226,7 @@ describe('ms(multipleunits)', () => {
     expect(parse('3seconds40s')).toBe(43000);
   });
 
+  it('should return NaN if invalid' , () => {
+      expect(Number.isNaN(parse('3h2failure'))).toBe(true);
+    })
 });


### PR DESCRIPTION
This is my attempt to fix #54 that might help with the new upcoming release of ms. I don't have a lot of experience contributing to open source so it might not be the most optimal solution to the issue, but I'm open to suggestions.

The changes I've implemented redirect `return NaN;` to a new function `multipleUnits` that loops around the whole string and adds the resulting milliseconds with `reduce`, finding all substrings that match the number-unit format and using the parse function on them or returning `NaN` if no match is found or if sections of the string do not match the format.

For the time being, it allows multiple instances of the same unit and does not check if the time order of the units entered is correct. This is obviously not a professional solution, but I would need some help to figure out how to forbid such format. As expressed before, I take any suggestions regarding fixing this new issue.

Finally, I want to clarify I'm not experienced on testing, so I would like some opinions on the tests I added, their format and some other test that could be convenient.

Thank you for considering checking on my attempt.