### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -27,7 +27,7 @@ jobs:
           run_install: true
 
       - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -22,7 +22,7 @@ jobs:
           run_install: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -26,7 +26,7 @@ jobs:
           run_install: true
 
       - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm


### PR DESCRIPTION
This PR pins GitHub Actions to exact commit SHAs for more reproducible builds.

## Why pin to commit SHAs?

Pinning GitHub Actions to specific commit SHAs ensures your workflow uses the exact same version every time, preventing unexpected changes when an action publisher releases a new version. This improves security and reliability.

Learn more: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Changes

- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/release.yml`
- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/quality.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/test.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/quality.yml`
- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/release.yml`
- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/test.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/test.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/release.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/quality.yml`
