### PR TITLE
perf: use indexed capture groups instead of named ones in parse()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,20 +75,16 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?\d*\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
+    /^(-?\d*\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
       str,
     );
 
-  if (!match?.groups) {
+  if (!match) {
     return NaN;
   }
 
-  // Named capture groups need to be manually typed today.
-  // https://github.com/microsoft/TypeScript/issues/32098
-  const { value, unit = 'ms' } = match.groups as {
-    value: string;
-    unit: string | undefined;
-  };
+  const value = match[1];
+  const unit = match[2] ?? 'ms';
 
   const n = parseFloat(value);
 


### PR DESCRIPTION
Noticed that v4 is quite a bit slower than v2 (#273), so I dug into why.

The regex in `parse()` was changed to use named capture groups (`(?<value>...)`, `(?<unit>...)`) when the TypeScript rewrite happened. Named capture groups are slower in V8 — the engine needs to allocate an extra `groups` object and do property lookups instead of just reading an array index. This is a known V8 thing and it adds up fast in hot paths.

The fix is just switching back to indexed groups and reading `match[1]` / `match[2]`. No behavior change, just faster.

**Numbers on my machine (Node 20, 500k iterations over 8 inputs):**

| | time |
|---|---|
| before (named CG) | ~475ms |
| after (indexed CG) | ~286ms |

That's roughly **66% faster** for `parse()`, which lines up with what was reported in #273.

All 167 existing tests pass.