### PR TITLE
test: add missing month parsing and zero value coverage

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -40,6 +40,10 @@ describe('ms(string)', () => {
     expect(ms('1y')).toBe(31557600000);
   });
 
+  it('should convert mo to ms', () => {
+    expect(ms('1mo')).toBe(2629800000);
+  });
+
   it('should work with decimals', () => {
     expect(ms('1.5h')).toBe(5400000);
   });
@@ -114,6 +118,10 @@ describe('ms(long string)', () => {
 
   it('should convert weeks to ms', () => {
     expect(ms('1 week')).toBe(604800000);
+  });
+
+  it('should convert months to ms', () => {
+    expect(ms('1 month')).toBe(2629800000);
   });
 
   it('should convert years to ms', () => {
@@ -326,6 +334,28 @@ describe('ms(number)', () => {
     expect(ms(234234234)).toBe('3d');
 
     expect(ms(-234234234)).toBe('-3d');
+  });
+});
+
+// zero
+
+describe('ms(zero)', () => {
+  it('should handle zero as a string', () => {
+    expect(ms('0')).toBe(0);
+  });
+
+  it('should handle zero with unit', () => {
+    expect(ms('0ms')).toBe(0);
+    expect(ms('0s')).toBe(0);
+    expect(ms('0h')).toBe(0);
+  });
+
+  it('should handle zero as a number', () => {
+    expect(ms(0)).toBe('0ms');
+  });
+
+  it('should handle zero with long format', () => {
+    expect(ms(0, { long: true })).toBe('0 ms');
   });
 });
 


### PR DESCRIPTION
## Summary

While working with ms for cache TTL logic, I noticed the test suite has a gap: the `ms(string)` and `ms(long string)` sections test every supported unit **except months**. The `mo`/`month`/`months` unit is tested in `parse.test.ts` and `parse-strict.test.ts`, but not through the main `ms()` entry point.

Also, zero-value behavior was completely untested.

## Tests Added

**Month parsing via `ms()`:**
- `ms('1mo')` → `2629800000`
- `ms('1 month')` → `2629800000`

**Zero values:**
- `ms('0')` → `0`
- `ms('0ms')` / `ms('0s')` / `ms('0h')` → `0`
- `ms(0)` → `'0ms'`
- `ms(0, { long: true })` → `'0 ms'`

## Checks

- [x] `pnpm test` — 173 tests pass (Node.js + Edge Runtime)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] 100% code coverage maintained

No code changes — tests only.