### PR TITLE
fix: support scientific notation in parse() for format() roundtrip

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -327,6 +327,13 @@ describe('ms(number)', () => {
 
     expect(ms(-234234234)).toBe('-3d');
   });
+
+  it('should roundtrip format/parse for large numbers', () => {
+    const formatted = ms(Number.MAX_VALUE);
+    expect(typeof formatted).toBe('string');
+    const parsed = ms(formatted as `${number}`);
+    expect(parsed).not.toBeNaN();
+  });
 });
 
 // invalid inputs

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?\d*\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
+    /^(?<value>-?(?:\d*\.?\d+)(?:e[+-]?\d+)?) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
       str,
     );
 

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -78,6 +78,15 @@ describe('parse(string)', () => {
   it('should work with negative decimals starting with "."', () => {
     expect(parse('-.5h')).toBe(-1800000);
   });
+
+  it('should work with scientific notation (roundtrip from format)', () => {
+    expect(parse('5.696545792019405e+297y')).not.toBeNaN();
+    expect(parse('1e3ms')).toBe(1000);
+    expect(parse('1.5e2s')).toBe(150000);
+    expect(parse('-1e3ms')).toBe(-1000);
+    expect(parse('1E3ms')).toBe(1000);
+    expect(parse('1e+3ms')).toBe(1000);
+  });
 });
 
 // long strings


### PR DESCRIPTION
## Problem

`format()` can produce scientific notation for very large (but finite) numbers:

```js
format(Number.MAX_VALUE) // "5.696545792019405e+297y"
```

But `parse()` returns `NaN` for that string because the regex only matches standard decimal notation (`-?\d*\.?\d+`), not the `e+297` exponent suffix. This breaks the roundtrip contract between `format()` and `parse()`.

## Reproduction

```js
import { format, parse } from 'ms';

const formatted = format(Number.MAX_VALUE);
console.log(formatted);        // "5.696545792019405e+297y"
console.log(parse(formatted)); // NaN — can't parse its own output
```

## Fix

Extend the numeric capture group in the `parse()` regex to accept an optional exponent suffix (`e[+-]?\d+`). `parseFloat()` already handles scientific notation natively, so no downstream changes are needed.

**Before:** `-?\d*\.?\d+`
**After:** `-?(?:\d*\.?\d+)(?:e[+-]?\d+)?`

## Tests

- Added regression tests for scientific notation parsing (`1e3ms`, `1.5e2s`, `-1e3ms`, `1E3ms`, `1e+3ms`, the MAX_VALUE roundtrip)
- Added roundtrip test in `ms()` integration tests
- All 169 tests pass, 100% coverage maintained
- Verified in both Node.js and edge runtime environments

Fixes #284