### PR TITLE
fix(parse): support scientific notation for format() roundtrip

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -327,6 +327,10 @@ describe('ms(number)', () => {
 
     expect(ms(-234234234)).toBe('-3d');
   });
+
+  it('should roundtrip very large values that format in scientific notation', () => {
+    expect(ms(ms(Number.MAX_VALUE))).toBe(Number.MAX_VALUE);
+  });
 });
 
 // invalid inputs

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?\d*\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
+    /^(?<value>-?(?:\d*\.?\d+)(?:e[+-]?\d+)?) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
       str,
     );
 

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { parse } from './index';
+import { format, parse } from './index';
 
 describe('parse(string)', () => {
   it('should not throw an error', () => {
@@ -64,6 +64,20 @@ describe('parse(string)', () => {
 
   it('should work with numbers starting with .', () => {
     expect(parse('.5ms')).toBe(0.5);
+  });
+
+  it('should parse scientific notation values', () => {
+    expect(parse('1e3ms')).toBe(1000);
+    expect(parse('1.5e2s')).toBe(150000);
+    expect(parse('-1e3ms')).toBe(-1000);
+    expect(parse('1E3ms')).toBe(1000);
+    expect(parse('1e+3ms')).toBe(1000);
+  });
+
+  it('should roundtrip format output with scientific notation', () => {
+    const formatted = format(Number.MAX_VALUE);
+    expect(formatted).toMatch(/e[+-]\d+y$/i);
+    expect(parse(formatted)).toBe(Number.MAX_VALUE);
   });
 
   it('should work with negative integers', () => {


### PR DESCRIPTION
## Summary
Allow `parse()` to read scientific notation produced by `format()` for very large millisecond values.

## Problem
Fixes #284. `format(Number.MAX_VALUE)` yields `"5.696545792019405e+297y"`, but `parse()` returned `NaN` because the numeric regex only matched plain decimals.

## Fix
Extend the value capture group to accept an optional exponent suffix (`e[+-]?\d+`). `parseFloat()` already handles the matched value.

## Test plan
- [x] `pnpm test` — 170 passed (Node + edge runtime)
- [x] Scientific notation parse cases (`1e3ms`, `1.5e2s`, `-1e3ms`, etc.)
- [x] `ms(ms(Number.MAX_VALUE))` roundtrip regression