### PR TITLE
fix(parse): remove ambiguous numeric regex to prevent ReDoS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?\d*\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
+    /^(?<value>-?(?:\d+\.?\d*|\.\d+)) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
       str,
     );
 

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -54,6 +54,12 @@ describe('parse(string)', () => {
     expect(Number.isNaN(parse('foo'))).toBe(true);
   });
 
+  it('should parse long invalid numeric strings without catastrophic backtracking', () => {
+    const start = performance.now();
+    expect(Number.isNaN(parse(`${'9'.repeat(99)}z`))).toBe(true);
+    expect(performance.now() - start).toBeLessThan(20);
+  });
+
   it('should be case-insensitive', () => {
     expect(parse('53 YeArS')).toBe(1672552800000);
     expect(parse('53 WeEkS')).toBe(32054400000);


### PR DESCRIPTION
## Summary
- Replace the backtracking-prone `\d*\.?\d+` numeric capture with `(?:\d+\.?\d*|\.\d+)`
- Complements the existing 100-character input guard with a safer regex shape
- Add regression test ensuring long invalid numeric strings parse quickly

Fixes #291

## Test plan
- [x] `pnpm test`