### PR TITLE
Fix parseStrict README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ import { parseStrict } from 'ms';
 parseStrict('1h'); // 3600000
 
 function example(s: string) {
-  return parseStrict(str); // tsc error
+  return parseStrict(s); // tsc error
 }
 ```
 


### PR DESCRIPTION
## Summary

Fixes the `parseStrict` README example so it passes the function argument `s` instead of the undefined `str` identifier.

## Validation

- `git diff --check`

This is a docs-only change. I also attempted the full test script locally, but this checkout has no installed `node_modules`, so the package test script could not start.