### PR TITLE
Fix parse regex backtracking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?\d*\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
+    /^(?<value>-?(?:\d+(?:\.\d+)?|\.\d+)) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
       str,
     );
 

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -54,6 +54,10 @@ describe('parse(string)', () => {
     expect(Number.isNaN(parse('foo'))).toBe(true);
   });
 
+  it('should return NaN for invalid max-length numeric input', () => {
+    expect(Number.isNaN(parse(`${'9'.repeat(99)}z`))).toBe(true);
+  });
+
   it('should be case-insensitive', () => {
     expect(parse('53 YeArS')).toBe(1672552800000);
     expect(parse('53 WeEkS')).toBe(32054400000);


### PR DESCRIPTION
## Summary
- Tighten the numeric part of the parse regex to avoid ambiguous digit matching.
- Add coverage for invalid max-length numeric input returning `NaN`.

Fixes #291.

## Test plan
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`