### PR TITLE
fix(parse): support scientific notation in string parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?\d*\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
+    /^(?<value>-?\d*\.?\d+(?:[eE][-+]?\d+)?) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
       str,
     );
 

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from '@jest/globals';
 import { parse } from './index';
 
 describe('parse(string)', () => {
+  it('should support scientific notation', () => {
+    expect(parse('5.696545792019405e+297y')).toBe(5.696545792019405e+297 * 31557600000);
+    expect(parse('1.5e3ms')).toBe(1500);
+  });
   it('should not throw an error', () => {
     expect(() => {
       parse('1m');


### PR DESCRIPTION
Fixes #284 by updating the regex in \parse()\ to correctly handle scientific notation (e.g. \1.5e3ms\ or \5.696545792019405e+297y\). This ensures that output generated by \ormat()\ for extremely large numbers can be successfully parsed back by \parse()\, restoring the round-trip contract between the two functions.