### PR TITLE
perf(parse): resolve 40% performance regression by using positional capture groups

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,20 +75,16 @@ export function parse(str: string): number {
     );
   }
   const match =
-    /^(?<value>-?\d*\.?\d+) *(?<unit>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
+    /^(-?\d*\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|months?|mo|years?|yrs?|y)?$/i.exec(
       str,
     );
 
-  if (!match?.groups) {
+  if (!match) {
     return NaN;
   }
 
-  // Named capture groups need to be manually typed today.
-  // https://github.com/microsoft/TypeScript/issues/32098
-  const { value, unit = 'ms' } = match.groups as {
-    value: string;
-    unit: string | undefined;
-  };
+  const value = match[1];
+  const unit = match[2] || 'ms';
 
   const n = parseFloat(value);
 


### PR DESCRIPTION
Fixes #273.

The recent TypeScript rewrite in \4.0.0\ introduced a significant performance regression (>40% slower) during parsing, which was tracked down to the use of named capture groups (\?<value>\ and \?<unit>\). Executing Regex with named capture groups incurs substantial overhead in V8 compared to standard positional capture groups.

By replacing the named capture groups with simple positional groups, we restore the \ms\ parsing performance back to its pre-\4.0.0\ baseline while keeping 100% of the TypeScript safety and logic. All tests still pass!